### PR TITLE
Custom class to cells (td)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ export default {
           field: 'name',
           html: false,
           filterable: true,
+          class: 'my-custom-class'
         },
         {
           label: 'Age',
@@ -321,6 +322,11 @@ This should result in the screenshot seen above
       <td>width (optional)</td>
       <td>provide a width value for this column</td>
       <td>example: <code>width: '50px'</code></td>
+    </tr>
+    <tr>
+      <td>class (optional)</td>
+      <td>provide custom class(es) to the td</td>
+      <td>example: <code>class: 'text-center'</code></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ export default {
           type: 'number',
           html: false,
           width: '50px',
+          thClass: 'only-th-class',
         },
         {
           label: 'Name',
           field: 'name',
           html: false,
           filterable: true,
-          class: 'my-custom-class'
+          tdClass: 'text-center'
         },
         {
           label: 'Age',
@@ -324,9 +325,14 @@ This should result in the screenshot seen above
       <td>example: <code>width: '50px'</code></td>
     </tr>
     <tr>
-      <td>class (optional)</td>
+      <td>tdClass (optional)</td>
       <td>provide custom class(es) to the td</td>
       <td>example: <code>class: 'text-center'</code></td>
+    </tr>
+    <tr>
+      <td>thClass (optional)</td>
+      <td>provide custom class(es) to the th</td>
+      <td>example: <code>class: 'custom-th-style'</code></td>
     </tr>
   </tbody>
 </table>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -232,16 +232,20 @@ import format from 'date-fns/format';
       //---------------------------------------------------------
       getDataStyle(index) {
         var classString = '';
-        switch (this.columns[index].type) {
-          case 'number':
-          case 'percentage':
-          case 'decimal': 
-          case 'date':
-            classString = 'right-align ';
-          break;
-          default:
-            classString = 'left-align ';
+        if (this.columns[index].hasOwnProperty('class')) {
+          classString = this.columns[index].class;
+        } else {
+          switch (this.columns[index].type) {
+            case 'number':
+            case 'percentage':
+            case 'decimal': 
+            case 'date':
+              classString = 'right-align ';
             break;
+            default:
+              classString = 'left-align ';
+              break;
+          }
         }
         return classString;
       },

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -41,7 +41,7 @@
         <tr v-for="(row, index) in paginated" :class="onClick ? 'clickable' : ''" @click="click(row, index)">
           <th v-if="lineNumbers" class="line-numbers">{{ getCurrentIndex(index) }}</th>
           <slot name="table-row" :row="row">
-            <td v-for="(column, i) in columns" :class="getDataStyle(i)">
+            <td v-for="(column, i) in columns" :class="getDataStyle(i, 'td')">
               <span v-if="!column.html">{{ collectFormatted(row, column) }}</span>
               <span v-if="column.html" v-html="collect(row, column.field)"></span>
             </td>
@@ -224,16 +224,16 @@ import format from 'date-fns/format';
             classString += 'sorting-asc ';
           }
         }
-        classString += this.getDataStyle(index);
+        classString += this.getDataStyle(index, 'th');
         return classString;
       },
       // given column index, we can figure out what style classes
       // to apply to this data
       //---------------------------------------------------------
-      getDataStyle(index) {
+      getDataStyle(index, type) {
         var classString = '';
-        if (this.columns[index].hasOwnProperty('class')) {
-          classString = this.columns[index].class;
+        if (typeof type !== 'undefined' && this.columns[index].hasOwnProperty(type + 'Class')) {
+          classString = this.columns[index][type + 'Class'];
         } else {
           switch (this.columns[index].type) {
             case 'number':


### PR DESCRIPTION
Ref. Issue #14 

With the `tdClass` option in the column object, you can set your own class(es) to the cell.
With the `thClass` one, you can set classes for the th.

If provided, they will override their default classes (set by the column type).