### PR TITLE
Add FormatOutput param to column's param

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -237,7 +237,13 @@ import {format, parse, compareAsc} from 'date-fns/esm'
         var value = this.collect(obj, column.field);
 
         if (value === undefined) return '';
+
         //lets format the resultant data
+        if (typeof(column.formatOutput) === 'function') {
+          let callback = column.formatOutput;
+          return callback.call( this, value );
+        }
+
         switch(column.type) {
           case 'decimal':
             return formatDecimal(value);


### PR DESCRIPTION
I have seen the 'type' param but it's very limited, isn't it better to allow devs to define a function to formate the way they need? For example:

{
	label: 'Price',
	field: 'price',
	formatOutput: function ( value ) {
		return this.$currencyFormatter.format(value, { code: 'USD' });
	}
}