### PR TITLE
Added before and after table-row slots.

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -54,12 +54,14 @@
         <tbody>
           <tr v-for="(row, index) in paginated" :class="onClick ? 'clickable' : ''" @click="click(row, index)">
             <th v-if="lineNumbers" class="line-numbers">{{ getCurrentIndex(index) }}</th>
+            <slot name="table-row-before" :row="row" :index="index"></slot>
             <slot name="table-row" :row="row" :formattedRow="formattedRow(row)" :index="index">
               <td v-for="(column, i) in columns" :class="getDataStyle(i, 'td')" v-if="!column.hidden">
                 <span v-if="!column.html">{{ collectFormatted(row, column) }}</span>
                 <span v-if="column.html" v-html="collect(row, column.field)"></span>
               </td>
             </slot>
+            <slot name="table-row-after" :row="row" :index="index"></slot>
           </tr>
           <tr v-if="processedRows.length === 0">
             <td :colspan="columns.length">


### PR DESCRIPTION
If you have many columns and want custom columns with actions you have to write all columns again?
```vue
<template slot="table-row" slot-scope="props">
  <td><input type="checkbox" /></td>
  // other columns start (over 20)
  <td><img src="{{ props.row.imageLink }}"/></td>
  <td>{{ props.row.productName }}</td>
  <td>{{ props.row.productCode }}</td>
  <td>{{ props.row.salePrice }}</td>
  // other columns end
  <td><button @click="doSomething(props.index)">show</button></td>
</template>  
```

I added two more slots for adding cols before and after the table-row. For example:
```vue
<template slot="table-row-before" slot-scope="props">
  <td><input type="checkbox" /></td>
</template>

<template slot="table-row-after" slot-scope="props">
  <td><button @click="doSomething(props.index)">show</button></td>
</template>
```