### PR TITLE
Only parse date when it is a valid date.

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -126,7 +126,7 @@
 </template>
 
 <script>
-import {format, parse, compareAsc} from 'date-fns/esm'
+  import {format, parse, compareAsc, isValid} from 'date-fns/esm'
   export default {
     name: 'vue-good-table',
     props: {
@@ -529,6 +529,12 @@ import {format, parse, compareAsc} from 'date-fns/esm'
 
             // date comparison here
             if (this.columns[this.sortColumn].type === 'date') {
+              if (!isValid(x)) {
+                return -1 * (this.sortType === 'desc' ? -1 : 1);
+              }
+              if (!isValid(y)) {
+                return (this.sortType === 'desc' ? -1 : 1);
+              }
               return (compareAsc(x, y)) * (this.sortType === 'desc' ? -1 : 1);
             }
 


### PR DESCRIPTION
Otherwise put them in the beginning (mainly for empty dates). I always got an 'Invalid Date' when my date field was empty instead of an empty date. It also had problems sorting it.