### PR TITLE
Fix nuxt export error.

### DIFF
--- a/src/components/types/date.js
+++ b/src/components/types/date.js
@@ -1,4 +1,4 @@
-import { format, parse, isValid, compareAsc } from 'date-fns/esm';
+import { format, parse, isValid, compareAsc } from 'date-fns';
 import clone from 'lodash.clone';
 import def from './default';
 


### PR DESCRIPTION
Fixes nuxt render error:
```js
nuxt:render Rendering url /cities +0ms
{ <project path>\node_modules\date-fns\esm\index.js:3
export {default as addDays} from './addDays/index.js'
^^^^^^

SyntaxError: Unexpected token export
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:616:28)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (<project path>\node_modules\vue-good-table\dist\vue-good-table.cjs.js:17:11)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at r (<project path>\node_modules\vue-server-renderer\build.js:8330:16)
    at Object.<anonymous> (server-bundle.js:3497:18)
    at __webpack_require__ (webpack:/webpack/bootstrap 0ffea5611571bee8e9a5:25:0)
    at Object.<anonymous> (plugins/vue-good-table.js:1:0)
    at __webpack_require__ (webpack:/webpack/bootstrap 0ffea5611571bee8e9a5:25:0) statusCode: 500, name: 'SyntaxError' }
```