### PR TITLE
Filter by formatted value.

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -727,14 +727,14 @@ export default {
                 if (col.filterOptions
                   && typeof col.filterOptions.filterFn === 'function') {
                   return col.filterOptions.filterFn(
-                    this.collect(row, col.field),
+                    this.collectFormatted(row, col),
                     this.columnFilters[col.field]
                   );
                 }
                 // Otherwise Use default filters
                 const { typeDef } = col;
                 return typeDef.filterPredicate(
-                  this.collect(row, col.field),
+                  this.collectFormatted(row, col),
                   this.columnFilters[col.field]
                 );
               });


### PR DESCRIPTION
When I use `formatFn` to transform original object data to formatted string. And after that I tried to filter by this column I got error.

I think it is a good idea to filter by value that you see in table, but not by original not formatted value.