### PR TITLE
Update Filters Immediately on enter pressed

### DIFF
--- a/src/components/VgtFilterRow.vue
+++ b/src/components/VgtFilterRow.vue
@@ -14,7 +14,7 @@
         :placeholder="getPlaceholder(column)"
         :value="columnFilters[column.field]"
         @keyup.enter="updateFiltersOnEnter(column, $event.target.value)"
-        v-on:input="updateFiltersOnKeyup(column, $event.target.value)" />
+        @input="updateFiltersOnKeyup(column, $event.target.value)" />
 
       <!-- options are a list of primitives -->
       <select v-if="isDropdownArray(column)"
@@ -116,7 +116,8 @@ export default {
     },
 
     updateFiltersOnEnter(column, value) {
-      this.updateFilters(column, value);
+      if (this.timer) clearTimeout(this.timer);
+      this.updateFiltersImmediately(column, value);
     },
 
     updateFiltersOnKeyup(column, value) {


### PR DESCRIPTION
What this does is skip the 400ms delay when `filterOptions: { enabled: true, trigger: 'enter' }` is set.

**Why:**

 * It feels sluggish when you press enter and there is a 0.4 second delay before anything happens
 * Removal of `setTimeOut` makes writing tests that involve filtering much simpler

Because the `updateFiltersOnEnter` can still be called when you are not using `trigger: 'enter'`, that means the user could type a phrase, then press enter, then 400 ms later trigger another request. So we `clearTimeout` on the `updateFiltersOnEnter` method too.