### PR TITLE
import only needed functions from date-fns

### DIFF
--- a/src/components/types/date.js
+++ b/src/components/types/date.js
@@ -1,4 +1,7 @@
-import { format, parse, isValid, compareAsc } from 'date-fns';
+var format = require('date-fns/format');
+var parse = require('date-fns/parse');
+var isValid = require('date-fns/isValid');
+var compareAsc = require('date-fns/compareAsc');
 import clone from 'lodash.clone';
 import def from './default';
 


### PR DESCRIPTION
Hello,

There is a way to import only the needed functions from date-fns, so  i replaced those imports to get a smaller size of dependencies. #350 

original stats
```
Built in 10.59s.

┌─────────────────────────────────────────────────┐
│file                         size       gzip size│
│dist/vue-good-table.cjs.js   72.72 KB   14.45 KB │
│dist/vue-good-table.es.js    72.38 KB   14.35 KB │
│dist/vue-good-table.js       361.52 KB  70.17 KB │
│dist/vue-good-table.min.js   94.44 KB   28 KB    │
│dist/vue-good-table.min.css  12.93 KB   2.4 KB   │
│dist/vue-good-table.css      16.16 KB   2.84 KB  │
└─────────────────────────────────────────────────┘
```

new stats
```
Built in 8.65s.

┌─────────────────────────────────────────────────┐
│file                         size       gzip size│
│dist/vue-good-table.cjs.js   72.81 KB   14.47 KB │
│dist/vue-good-table.es.js    72.49 KB   14.37 KB │
│dist/vue-good-table.js       277.96 KB  55.41 KB │
│dist/vue-good-table.min.js   73.4 KB    21.11 KB │
│dist/vue-good-table.min.css  12.93 KB   2.4 KB   │
│dist/vue-good-table.css      16.16 KB   2.84 KB  │
└─────────────────────────────────────────────────┘
```