### PR TITLE
Fix repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "docs:build": "vuepress build vp-docs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/xaksis/vue-good-table"
-  },
+  "repository": "github:xaksis/vue-good-table",
   "keywords": [
     "vue",
     "vuejs",


### PR DESCRIPTION
The current `repository` field in `package.json` is invalid. This PR updates it to use the recommended format for GitHub.

See: https://docs.npmjs.com/files/package.json#repository