### PR TITLE
Include CSS in Webpack production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-good-table",
   "version": "2.14.3",
-  "sideEffects": false,
+  "sideEffects": [ "*.css" ],
   "description": "A simple, clean data table for VueJS (2.x) with essential features like sorting, column filtering, pagination etc",
   "main": "dist/vue-good-table.cjs.js",
   "module": "dist/vue-good-table.es.js",


### PR DESCRIPTION
Currently, Webpack omits `vue-good-table`'s CSS files from production builds because it does not recognize them as side effects. This breaks the usage specified in the project documentation.

Read more: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free