### PR TITLE
"*.css" sideEffects - fix css not included in prod build (webpack4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "vue-good-table",
   "version": "2.14.6",
   "sideEffects": [
-    "*.vue"
+    "*.vue",
+    "*.css"
   ],
   "description": "A simple, clean data table for VueJS (2.x) with essential features like sorting, column filtering, pagination etc",
   "main": "dist/vue-good-table.cjs.js",


### PR DESCRIPTION
in my production webpack4 build the CSS for vue-good-table wasn't included in production builds (all dev builds were okay)

After some digging I've confirmed adding `*.css` to `sideEffects` in package.json fixes this issue.
Since css modifies the DOM it is counted as having side effects by webpack4 when it does its treeshaking and all that.

Can provide links to demo if you like.