### PR TITLE
Add slot for table footer

### DIFF
--- a/dev/grouped-table.vue
+++ b/dev/grouped-table.vue
@@ -17,6 +17,15 @@
       headerPosition: 'top',
     }"
     styleClass="vgt-table condensed bordered">
+    <template slot="table-footer-row" slot-scope="props">
+      <tr>
+        <td colspan="100%">
+          <span>
+            The {{props.rows.filter(x => x.count === Math.max.apply(Math, props.rows.map(row => { return row.count;})))[0].name}} is the animal with the highest count: {{props.rows.filter(x => x.count === Math.max.apply(Math, props.rows.map(row => { return row.count;})))[0].count}}
+          </span>
+        </td>
+      </tr>     
+    </template>
     <!-- <template slot="table-header-row" slot-scope="props">
       <span v-if="props.row.mode === 'span'">
         My header label is - <strong>{{ props.row.label }}</strong>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -261,6 +261,12 @@
                 </slot>
               </template>
             </vgt-header-row>
+              <slot 
+                name="table-footer-row"
+                :rows="headerRow.children"
+                :column="columns"
+              >
+              </slot>
           </tbody>
 
           <tbody v-if="showEmptySlot">


### PR DESCRIPTION
This can be used to add a footer when using the grouped-table option