### PR TITLE
Add groupOptions.customChildObject option

### DIFF
--- a/dev/grouped-table.vue
+++ b/dev/grouped-table.vue
@@ -4,7 +4,10 @@
     :columns="columns"
     :rows="rows"
     :line-numbers="true"
-    :select-options="{enabled: true}"
+    :select-options="{
+      enabled: true,
+      selectAllByGroup: true
+    }"
     @on-select-all="onSelectAll"
     @on-search="onSelectAll"
     @on-row-mouseenter="onMouseover"
@@ -14,8 +17,8 @@
     }"
     :group-options="{
       enabled: true,
-      headerPosition: 'top',
-      customChildObject: 'episodes'
+      headerPosition: 'bottom',
+      mode: 'span'
     }"
     styleClass="vgt-table condensed bordered">
     <!-- <template slot="table-header-row" slot-scope="props">
@@ -71,6 +74,7 @@ export default {
           ],
         },
         {
+          label: 'Reptile Total',
           name: 'Reptile Total',
           diet: '',
           count: '',

--- a/dev/grouped-table.vue
+++ b/dev/grouped-table.vue
@@ -15,6 +15,7 @@
     :group-options="{
       enabled: true,
       headerPosition: 'top',
+      customChildObject: 'episodes'
     }"
     styleClass="vgt-table condensed bordered">
     <!-- <template slot="table-header-row" slot-scope="props">

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -772,7 +772,7 @@ export default {
       if (this.sorts.length) {
         //* we need to sort
         computedRows.forEach((cRows) => {
-          cRows[groupChildObject].sort((xRow, yRow) => {
+          cRows[this.groupChildObject].sort((xRow, yRow) => {
             //* we need to get column for each sort
             let sortValue;
             for (let i = 0; i < this.sorts.length; i += 1) {
@@ -1196,6 +1196,7 @@ export default {
       // or as a result of modifying rows.
       this.columnFilters = columnFilters;
       let computedRows = cloneDeep(this.originalRows);
+      const { groupChildObject } = this;
 
       // do we have a filter to care about?
       // if not we don't need to do anything

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -1,15 +1,28 @@
 <template>
 <tr>
   <th
-    v-if="headerRow.mode === 'span'"
+    v-if="spanColumns"
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan">
     <slot
       :row="headerRow"
+      :column="column"
       name="table-header-row">
       <span v-if="headerRow.html" v-html="headerRow.label">
       </span>
       <span v-else>
+        <template v-if="selectAllByGroup"
+        >
+          <slot name="table-header-group-select"
+            :columns="columns"
+            :row="headerRow"
+          >
+            <input
+              type="checkbox"
+              :checked="allSelected"
+              @change="toggleSelectGroup($event)" />
+          </slot>
+        </template>
         {{ headerRow.label }}
       </span>
     </slot>
@@ -17,28 +30,43 @@
   <!-- if the mode is not span, we display every column -->
   <th
     class="vgt-row-header"
-    v-if="headerRow.mode !== 'span' && lineNumbers"></th>
+    v-if="!spanColumns && lineNumbers"></th>
   <th
     class="vgt-row-header"
-    v-if="headerRow.mode !== 'span' && selectable"></th>
-  <th
-    v-if="headerRow.mode !== 'span' && !column.hidden"
-    v-for="(column, i) in columns"
-    :key="i"
-    class="vgt-row-header"
-    :class="getClasses(i, 'td')">
-    <slot
-      :row="headerRow"
-      :column="column"
-      :formattedRow="formattedRow(headerRow, true)"
-      name="table-header-row">
-      <span v-if="!column.html">
-        {{ collectFormatted(headerRow, column, true) }}
-      </span>
-      <span v-if="column.html" v-html="collectFormatted(headerRow, column, true)">
-      </span>
-    </slot>
+    v-if="!spanColumns && selectable">
+    <template v-if="selectAllByGroup"
+    >
+      <slot name="table-header-group-select"
+        :columns="columns"
+        :row="headerRow"
+      >
+        <input
+          type="checkbox"
+          :checked="allSelected"
+          @change="toggleSelectGroup($event)" />
+      </slot>
+    </template>
   </th>
+  <template v-if="!spanColumns"> 
+    <th
+      v-for="(column, i) in hiddenColumns"
+      :key="i"
+      class="vgt-row-header"
+      :class="getClasses(i, 'td')">
+      
+      <slot
+        :row="headerRow"
+        :column="column"
+        :formattedRow="formattedRow(headerRow, true)"
+        name="table-header-row">
+        <span v-if="!column.html">
+          {{ collectFormatted(headerRow, column, true) }}
+        </span>
+        <span v-if="column.html" v-html="collectFormatted(headerRow, column, true)">
+        </span>
+      </slot>
+    </th>
+  </template>
 </tr>
 </template>
 
@@ -58,6 +86,12 @@ export default {
     selectable: {
       type: Boolean,
     },
+    selectAllByGroup: {
+      type: Boolean
+    },
+    groupChildObject: {
+      type: String
+    },
     collectFormatted: {
       type: Function,
     },
@@ -70,19 +104,40 @@ export default {
     fullColspan: {
       type: Number,
     },
+    groupIndex: {
+      type: Number
+    },
+    groupOptions: {
+      type: Object
+    }
   },
   data() {
     return {
     };
   },
   computed: {
+    allSelected() {
+      const { headerRow, groupChildObject } = this;
+      return headerRow[groupChildObject].filter((row) => row.vgtSelected).length === headerRow[groupChildObject].length;
+    },
+    hiddenColumns() {
+      const { columns } = this;
+      return columns.filter(column => !column.hidden)
+    },
+    spanColumns() {
+      const { headerRow, groupOptions } = this;
+      return headerRow.mode === 'span' || groupOptions.mode === 'span';
+    }
   },
   methods: {
+    toggleSelectGroup(event) {
+      this.$emit('on-select-group-change', {groupIndex: this.groupIndex, checked: event.target.checked});
+    }
   },
   mounted() {
   },
   components: {
-  },
+  }
 };
 </script>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8966,7 +8966,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.29.6, webpack@^4.8.1, webpack@^4.9.1:
+webpack@^4.28.4, webpack@^4.8.1, webpack@^4.9.1:
   version "4.29.6"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.29.6.tgz#66bf0ec8beee4d469f8b598d3988ff9d8d90e955"
   dependencies:


### PR DESCRIPTION
Add groupOptions.customChildObject option.  …
This will allow a user to use a different property then the default 'children'

Currently when you want to use the grouped table option. You will need to have some control over the data provided. It requires you to have an array of arrays, where the sub-array is addressed through the property 'children'. In some situations you might not have any influence on how the data is structured, and you need to recreate the structure, which can ben very resource costly.

I'm proposing an optional parameter, where you can at least change the default property 'children' into something else.

In this branch i've also added the feature to use checkboxes per headerGroup.
I can separate these PR's if your interested.

Checking the checkbox in front of the header's label, will select all checkboxes in it's children.
De-selecting one of it's children will deselect the header group.

![image](https://user-images.githubusercontent.com/1331394/54482646-332d5e80-4847-11e9-8804-add6d5ff0841.png)
