### PR TITLE
Fix Failed to execute 'getComputedStyle' on 'Window'

### DIFF
--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -172,7 +172,7 @@ export default {
     },
 
     getWidthStyle(dom) {
-      if (window && window.getComputedStyle) {
+      if (window && window.getComputedStyle && dom) {
         const cellStyle = window.getComputedStyle(dom, null);
         return {
           width: cellStyle.width,


### PR DESCRIPTION
Related to issue #590, when the hidden = true property is added in a column, the getWidthStyle function receives the dom parameter as undefined for that column. 