### PR TITLE
Feature/collapsable groups

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -39,7 +39,7 @@
     <h3>Remote Table</h3>
     <remote-table/>
     <h3>Grouped Table</h3>
-    <!-- <grouped-table></grouped-table> -->
+     <grouped-table></grouped-table>
   </div>
 </template>
 

--- a/dev/grouped-table.vue
+++ b/dev/grouped-table.vue
@@ -15,6 +15,7 @@
     :group-options="{
       enabled: true,
       headerPosition: 'top',
+      collapsable: true
     }"
     styleClass="vgt-table condensed bordered">
     <!-- <template slot="table-header-row" slot-scope="props">

--- a/dev/grouped-table.vue
+++ b/dev/grouped-table.vue
@@ -1,5 +1,7 @@
 <template>
 <div>
+  <button @click="expandAll">Expand All</button>
+  <button @click="collapseAll">Collapse All</button>
   <vue-good-table
     :columns="columns"
     :rows="rows"
@@ -15,9 +17,11 @@
     :group-options="{
       enabled: true,
       headerPosition: 'top',
-      collapsable: true
+      collapsable: 2
     }"
-    styleClass="vgt-table condensed bordered">
+    styleClass="vgt-table condensed bordered"
+    ref="groupedTable"
+  >
     <!-- <template slot="table-header-row" slot-scope="props">
       <span v-if="props.row.mode === 'span'">
         My header label is - <strong>{{ props.row.label }}</strong>
@@ -97,6 +101,12 @@ export default {
   computed: {
   },
   methods: {
+    expandAll() {
+      this.$refs.groupedTable.expandAll();
+    },
+    collapseAll() {
+      this.$refs.groupedTable.collapseAll();
+    },
     onSelectAll(params) {
       console.log(params);
     },

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -896,6 +896,18 @@ export default {
       }
     },
 
+    expandAll() {
+      this.filteredRows.forEach((row) => {
+        this.$set(row, 'vgtIsExpanded', true);
+      });
+    },
+
+    collapseAll() {
+      this.filteredRows.forEach((row) => {
+        this.$set(row, 'vgtIsExpanded', false);
+      });
+    },
+
     getColumnForField(field) {
       for (let i = 0; i < this.typedColumns.length; i += 1) {
         if (this.typedColumns[i].field === field) return this.typedColumns[i];

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -155,6 +155,7 @@
               :columns="columns"
               :line-numbers="lineNumbers"
               :selectable="selectable"
+              :collapsable="groupOptions.collapsable"
               :collect-formatted="collectFormatted"
               :formatted-row="formattedRow"
               :get-classes="getClasses"
@@ -176,7 +177,7 @@
             </vgt-header-row>
             <!-- normal rows here. we loop over all rows -->
             <tr
-              v-if="headerRow.vgtIsExpanded"
+              v-if="groupOptions.collapsable ? headerRow.vgtIsExpanded : true"
               v-for="(row, index) in headerRow.children"
               :key="row.originalIndex"
               :class="getRowStyleClass(row)"

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -891,7 +891,7 @@ export default {
   methods: {
     toggleExpand(index) {
       let headerRow = this.filteredRows[index];
-      if(headerRow) {
+      if (headerRow) {
         this.$set(headerRow, 'vgtIsExpanded', !headerRow.vgtIsExpanded);
       }
     },

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -150,6 +150,7 @@
             <!-- if group row header is at the top -->
             <vgt-header-row
               v-if="groupHeaderOnTop"
+              @vgtExpand="toggleExpand(index)"
               :header-row="headerRow"
               :columns="columns"
               :line-numbers="lineNumbers"
@@ -175,6 +176,7 @@
             </vgt-header-row>
             <!-- normal rows here. we loop over all rows -->
             <tr
+              v-if="headerRow.vgtIsExpanded"
               v-for="(row, index) in headerRow.children"
               :key="row.originalIndex"
               :class="getRowStyleClass(row)"
@@ -886,6 +888,13 @@ export default {
   },
 
   methods: {
+    toggleExpand(index) {
+      let headerRow = this.filteredRows[index];
+      if(headerRow) {
+        this.$set(headerRow, 'vgtIsExpanded', !headerRow.vgtIsExpanded);
+      }
+    },
+
     getColumnForField(field) {
       for (let i = 0; i < this.typedColumns.length; i += 1) {
         if (this.typedColumns[i].field === field) return this.typedColumns[i];

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -87,7 +87,7 @@ export default {
   },
   methods: {
     columnCollapsable: function (currentIndex) {
-      if(this.collapsable === true) {
+      if (this.collapsable === true) {
         return currentIndex === 0;
       }
       return currentIndex === this.collapsable;

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -5,7 +5,7 @@
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan"
     @click="$emit('vgtExpand')">
-    <span v-if="collapsable" class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded, '': !headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       name="table-header-row">
@@ -30,7 +30,7 @@
     class="vgt-row-header"
     :class="getClasses(i, 'td')"
     @click="$emit('vgtExpand')">
-    <span v-if="collapsable && i === 0" class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable && i === 0" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded, '': !headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"
@@ -109,18 +109,12 @@ export default {
       margin-top:  -6px;
       border-top: 6px solid transparent;
       border-bottom: 6px solid transparent;
-    }
-    &.down::after{
-      border-left: 6px solid transparent;
-      border-right: 6px solid transparent;
-      border-top: 6px solid black;
-      border-bottom: 0px solid transparent;
-      margin-left:  -6px;
-    }
-
-    &.right::after{
       border-left:  6px solid black;
       margin-left:  -3px;
+      transition: 0.3s ease transform;
+    }
+    &.expand::after{
+      transform: rotate(90deg);
     }
   }
 

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -5,7 +5,7 @@
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan"
     @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
-    <span v-if="collapsable" class="triangle" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable" class="triangle" :class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       name="table-header-row">
@@ -30,7 +30,7 @@
     class="vgt-row-header"
     :class="getClasses(i, 'td')"
     @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
-    <span v-if="collapsable && i === 0" class="triangle" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable && i === 0" class="triangle" :class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -5,7 +5,7 @@
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan"
     @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
-    <span v-if="collapsable" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable" class="triangle" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       name="table-header-row">
@@ -30,7 +30,7 @@
     class="vgt-row-header"
     :class="getClasses(i, 'td')"
     @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
-    <span v-if="collapsable && i === 0" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable && i === 0" class="triangle" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -29,8 +29,8 @@
     :key="i"
     class="vgt-row-header"
     :class="getClasses(i, 'td')"
-    @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
-    <span v-if="collapsable && i === 0" class="triangle" :class="{ 'expand': headerRow.vgtIsExpanded }"></span>
+    @click="columnCollapsable(i) ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
+    <span v-if="columnCollapsable(i)" class="triangle" :class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"
@@ -63,7 +63,8 @@ export default {
       type: Boolean,
     },
     collapsable: {
-      type: Boolean
+      type: [Boolean, Number],
+      default: false
     },
     collectFormatted: {
       type: Function,
@@ -85,6 +86,12 @@ export default {
   computed: {
   },
   methods: {
+    columnCollapsable: function (currentIndex) {
+      if(this.collapsable === true) {
+        return currentIndex === 0;
+      }
+      return currentIndex === this.collapsable;
+    }
   },
   mounted() {
   },

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -5,7 +5,7 @@
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan"
     @click="$emit('vgtExpand')">
-    <span class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable" class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       name="table-header-row">
@@ -30,7 +30,7 @@
     class="vgt-row-header"
     :class="getClasses(i, 'td')"
     @click="$emit('vgtExpand')">
-    <span class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable" class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"
@@ -61,6 +61,9 @@ export default {
     },
     selectable: {
       type: Boolean,
+    },
+    collapsable: {
+      type: Boolean
     },
     collectFormatted: {
       type: Function,

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -30,7 +30,7 @@
     class="vgt-row-header"
     :class="getClasses(i, 'td')"
     @click="$emit('vgtExpand')">
-    <span v-if="collapsable" class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
+    <span v-if="collapsable && i === 0" class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -4,8 +4,8 @@
     v-if="headerRow.mode === 'span'"
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan"
-    @click="$emit('vgtExpand')">
-    <span v-if="collapsable" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded, '': !headerRow.vgtIsExpanded }"></span>
+    @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
+    <span v-if="collapsable" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       name="table-header-row">
@@ -29,8 +29,8 @@
     :key="i"
     class="vgt-row-header"
     :class="getClasses(i, 'td')"
-    @click="$emit('vgtExpand')">
-    <span v-if="collapsable && i === 0" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded, '': !headerRow.vgtIsExpanded }"></span>
+    @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
+    <span v-if="collapsable && i === 0" class="chevron" v-bind:class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -3,7 +3,9 @@
   <th
     v-if="headerRow.mode === 'span'"
     class="vgt-left-align vgt-row-header"
-    :colspan="fullColspan">
+    :colspan="fullColspan"
+    @click="$emit('vgtExpand')">
+    <span class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       name="table-header-row">
@@ -26,7 +28,9 @@
     v-for="(column, i) in columns"
     :key="i"
     class="vgt-row-header"
-    :class="getClasses(i, 'td')">
+    :class="getClasses(i, 'td')"
+    @click="$emit('vgtExpand')">
+    <span class="chevron" v-bind:class="{ 'down': headerRow.vgtIsExpanded, 'right': !headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
       :column="column"
@@ -87,5 +91,34 @@ export default {
 </script>
 
 <style lang="scss">
+  .chevron{
+    width:  24px;
+    height:  24px;
+    border-radius: 15%;
+    position:  relative;
+    margin:  0px 8px;
+    &:after{
+      content:  '';
+      position:  absolute;
+      display:  block;
+      left:  50%;
+      top:  50%;
+      margin-top:  -6px;
+      border-top: 6px solid transparent;
+      border-bottom: 6px solid transparent;
+    }
+    &.down::after{
+      border-left: 6px solid transparent;
+      border-right: 6px solid transparent;
+      border-top: 6px solid black;
+      border-bottom: 0px solid transparent;
+      margin-left:  -6px;
+    }
+
+    &.right::after{
+      border-left:  6px solid black;
+      margin-left:  -3px;
+    }
+  }
 
 </style>

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -94,28 +94,5 @@ export default {
 </script>
 
 <style lang="scss">
-  .chevron{
-    width:  24px;
-    height:  24px;
-    border-radius: 15%;
-    position:  relative;
-    margin:  0px 8px;
-    &:after{
-      content:  '';
-      position:  absolute;
-      display:  block;
-      left:  50%;
-      top:  50%;
-      margin-top:  -6px;
-      border-top: 6px solid transparent;
-      border-bottom: 6px solid transparent;
-      border-left:  6px solid black;
-      margin-left:  -3px;
-      transition: 0.3s ease transform;
-    }
-    &.expand::after{
-      transform: rotate(90deg);
-    }
-  }
 
 </style>

--- a/src/styles/_table-th.scss
+++ b/src/styles/_table-th.scss
@@ -50,7 +50,7 @@ $sort-chevron-width: 5px;
     border-bottom: 2px solid $border-color;
     border-top: 2px solid $border-color;
     background-color: lighten($border-color, 10%);
-    .chevron{
+    .triangle{
       width:  24px;
       height:  24px;
       border-radius: 15%;

--- a/src/styles/_table-th.scss
+++ b/src/styles/_table-th.scss
@@ -51,22 +51,22 @@ $sort-chevron-width: 5px;
     border-top: 2px solid $border-color;
     background-color: lighten($border-color, 10%);
     .triangle {
-      width:  24px;
-      height:  24px;
+      width: 24px;
+      height: 24px;
       border-radius: 15%;
-      position:  relative;
-      margin:  0px 8px;
+      position: relative;
+      margin: 0px 8px;
       &:after {
-        content:  '';
-        position:  absolute;
-        display:  block;
-        left:  50%;
-        top:  50%;
-        margin-top:  -6px;
+        content: '';
+        position: absolute;
+        display: block;
+        left: 50%;
+        top: 50%;
+        margin-top: -6px;
         border-top: 6px solid transparent;
         border-bottom: 6px solid transparent;
-        border-left:  6px solid $text-color;
-        margin-left:  -3px;
+        border-left: 6px solid $text-color;
+        margin-left: -3px;
         transition: 0.3s ease transform;
       }
       &.expand:after {

--- a/src/styles/_table-th.scss
+++ b/src/styles/_table-th.scss
@@ -50,6 +50,29 @@ $sort-chevron-width: 5px;
     border-bottom: 2px solid $border-color;
     border-top: 2px solid $border-color;
     background-color: lighten($border-color, 10%);
+    .chevron{
+      width:  24px;
+      height:  24px;
+      border-radius: 15%;
+      position:  relative;
+      margin:  0px 8px;
+      &:after{
+        content:  '';
+        position:  absolute;
+        display:  block;
+        left:  50%;
+        top:  50%;
+        margin-top:  -6px;
+        border-top: 6px solid transparent;
+        border-bottom: 6px solid transparent;
+        border-left:  6px solid $text-color;
+        margin-left:  -3px;
+        transition: 0.3s ease transform;
+      }
+      &.expand::after{
+        transform: rotate(90deg);
+      }
+    }
   }
 
   thead th{

--- a/src/styles/_table-th.scss
+++ b/src/styles/_table-th.scss
@@ -50,13 +50,13 @@ $sort-chevron-width: 5px;
     border-bottom: 2px solid $border-color;
     border-top: 2px solid $border-color;
     background-color: lighten($border-color, 10%);
-    .triangle{
+    .triangle {
       width:  24px;
       height:  24px;
       border-radius: 15%;
       position:  relative;
       margin:  0px 8px;
-      &:after{
+      &:after {
         content:  '';
         position:  absolute;
         display:  block;
@@ -69,7 +69,7 @@ $sort-chevron-width: 5px;
         margin-left:  -3px;
         transition: 0.3s ease transform;
       }
-      &.expand::after{
+      &.expand:after {
         transform: rotate(90deg);
       }
     }

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -162,7 +162,7 @@ To expand/collapse all you can use the method called "expandAll" or "collapseAll
   :columns="columns"
   :rows="rows"
   :groupOptions="{
-  	enabled: true,
+    enabled: true,
     collapsable: true // or column index
   }"
 >

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -169,3 +169,8 @@ To expand/collapse all you can use the method called "expandAll" or "collapseAll
 >
 </vue-good-table>
 ```
+To expand/collapse all you can use the method called `expandAll` or `collapseAll`.
+```js
+this.$refs.myCustomTable.expandAll();
+this.$refs.myCustomTable.collapseAll();
+```

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -153,6 +153,7 @@ In this case header row expects a value for each column
   :::
 
 ## Collapsable Rows
+
 To allow the row to collapse and expand you can use the groupOption "collapsable". You can either pass in a boolean or a number. 
 If "collapsable" is set to "true" then it will default to making the first column collapsable. Otherwise, you can specify the column index number.
 To expand/collapse all you can use the method called "expandAll" or "collapseAll".

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -156,7 +156,6 @@ In this case header row expects a value for each column
 
 To allow the row to collapse and expand you can use the groupOption "collapsable". You can either pass in a boolean or a number. 
 If `collapsable` is set to `true` then it will default to making the first column collapsable. Alternatively, you can specify the column index number.
-To expand/collapse all you can use the method called "expandAll" or "collapseAll".
 ```html
 <vue-good-table
   ref="myCustomTable"

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -155,10 +155,11 @@ In this case header row expects a value for each column
 ## Collapsable Rows
 
 To allow the row to collapse and expand you can use the groupOption "collapsable". You can either pass in a boolean or a number. 
-If "collapsable" is set to "true" then it will default to making the first column collapsable. Otherwise, you can specify the column index number.
+If `collapsable` is set to `true` then it will default to making the first column collapsable. Alternatively, you can specify the column index number.
 To expand/collapse all you can use the method called "expandAll" or "collapseAll".
 ```html
 <vue-good-table
+  ref="myCustomTable"
   :columns="columns"
   :rows="rows"
   :groupOptions="{

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -151,3 +151,19 @@ In this case header row expects a value for each column
 - The column object can be accessed via `props.column`
 - You can access the formatted row data (for example - formatted date) via `props.formattedRow`
   :::
+
+## Collapsable Rows
+To allow the row to collapse and expand you can use the groupOption "collapsable". You can either pass in a boolean or a number. 
+If "collapsable" is set to "true" then it will default to making the first column collapsable. Otherwise, you can specify the column index number.
+To expand/collapse all you can use the method called "expandAll" or "collapseAll".
+```html
+<vue-good-table
+  :columns="columns"
+  :rows="rows"
+  :groupOptions="{
+  	enabled: true,
+    collapsable: true // or column index
+  }"
+>
+</vue-good-table>
+```


### PR DESCRIPTION
Add Feature for Issue: #388

![ezgif com-crop](https://user-images.githubusercontent.com/35530271/69657839-1178ae00-1049-11ea-9eac-727d0af2b2a6.gif)


Added the folowing options to groupOptions:
* collapsable - if true it will allow the groups to be collapsed, the default state is collapsed

Added an event:
* vgtExpand - which gets triggered whenever a headerRow is clicked on and sends the value of the new expanded value
