### PR TITLE
Introduce new column property firstSortType

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -77,6 +77,7 @@ export default {
           label: 'Age',
           field: 'age',
           type: 'number',
+          firstSortType: 'desc',
           filterOptions: {
             enabled: true,
             filterDropdownItems: [

--- a/src/components/utils/sort.js
+++ b/src/components/utils/sort.js
@@ -1,8 +1,16 @@
 
+const DEFAULT_SORT_TYPE = 'asc';
+
+function getCurrentPrimarySort(sortArray, column) {
+  return ( sortArray.length === 1 && sortArray[0].field === column.field )
+  ? sortArray[0].type
+  : undefined;
+}
+
 function getNextSort(currentSort) {
-  if (currentSort === 'asc') return 'desc';
-  // if (currentSort === 'desc') return null;
-  return 'asc';
+  return (currentSort === 'asc')
+    ? 'desc'
+    : DEFAULT_SORT_TYPE;
 }
 
 function getIndex(sortArray, column) {
@@ -13,40 +21,21 @@ function getIndex(sortArray, column) {
 }
 
 exports.primarySort = (sortArray, column) => {
-  if (sortArray.length
-    && sortArray.length === 1
-    && sortArray[0].field === column.field) {
-    const type = getNextSort(sortArray[0].type);
-    if (type) {
-      sortArray[0].type = getNextSort(sortArray[0].type);
-    } else {
-      sortArray = [];
-    }
-  } else {
-    sortArray = [{
-      field: column.field,
-      type: 'asc',
-    }];
-  }
-  return sortArray;
+  return [{
+    field: column.field,
+    type: getNextSort(getCurrentPrimarySort(sortArray, column)),
+  }];
 };
 
 exports.secondarySort = (sortArray, column) => {
-  //* this means that primary sort exists, we're
-  //* just adding a secondary sort
   const index = getIndex(sortArray, column);
   if (index === -1) {
     sortArray.push({
       field: column.field,
-      type: 'asc',
+      type: DEFAULT_SORT_TYPE,
     });
   } else {
-    const type = getNextSort(sortArray[index].type);
-    if (type) {
-      sortArray[index].type = type;
-    } else {
-      sortArray.splice(index, 1);
-    }
+    sortArray[index].type = getNextSort(sortArray[index].type);
   }
   return sortArray;
 };

--- a/src/components/utils/sort.js
+++ b/src/components/utils/sort.js
@@ -1,5 +1,8 @@
-
 const DEFAULT_SORT_TYPE = 'asc';
+
+function getColumnFirstSortType(column) {
+  return column.firstSortType || DEFAULT_SORT_TYPE;
+}
 
 function getCurrentPrimarySort(sortArray, column) {
   return ( sortArray.length === 1 && sortArray[0].field === column.field )
@@ -21,9 +24,10 @@ function getIndex(sortArray, column) {
 }
 
 exports.primarySort = (sortArray, column) => {
+  const currentPrimarySort = getCurrentPrimarySort(sortArray, column);
   return [{
     field: column.field,
-    type: getNextSort(getCurrentPrimarySort(sortArray, column)),
+    type: currentPrimarySort ? getNextSort(currentPrimarySort) : getColumnFirstSortType(column),
   }];
 };
 
@@ -32,7 +36,7 @@ exports.secondarySort = (sortArray, column) => {
   if (index === -1) {
     sortArray.push({
       field: column.field,
-      type: DEFAULT_SORT_TYPE,
+      type: getColumnFirstSortType(column),
     });
   } else {
     sortArray[index].type = getNextSort(sortArray[index].type);

--- a/vp-docs/guide/configuration/column-options.md
+++ b/vp-docs/guide/configuration/column-options.md
@@ -96,6 +96,27 @@ columns: [
 ]
 ```
 
+## firstSortType
+
+type `String (default: 'asc')`
+
+controls the first sort type when sorting by the column. If you want the first sort type for this column to be descending, set this property to 'desc'. Possible values:
+* _asc_ - the initial sort will be ascending
+* _desc_ - the initial sort will be descending 
+
+
+```javascript
+columns: [
+  { 
+    label: 'name',
+    field: 'user_name',
+    sortable: true,
+    firstSortType: 'desc'
+  },
+  // ...
+]
+```
+
 ## sortFn
 
 type `Function`


### PR DESCRIPTION
Currently the first sort on a column sorts always in ascending order. Sometimes the user expects the first sort to sort the data in descending order. For example in a table "Most visited pages", when sorting by visits *(sessions, users ...)* one would expect the default sort order to be descending. 

With the introduced firstSortType column property this behavior can be achieved.

**Notes:**
1. This change is non-breaking
2. The docs are also updated