### PR TITLE
Fix Sass not building in last release

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1534,5 +1534,7 @@ export default {
 </script>
 
 <style lang="scss">
+@import "node_modules/vue-select/dist/vue-select";
+
 @import "../styles/style";
 </style>

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,6 +1,3 @@
-// V-select plugin
-@import "../../../vue-select/dist/vue-select";
-
 // base table styles
 @import './variables';
 @import './utils';

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,5 +1,5 @@
 // V-select plugin
-@import "../../node_modules/vue-select/dist/vue-select";
+@import "../../../vue-select/dist/vue-select";
 
 // base table styles
 @import './variables';

--- a/vp-docs/.vuepress/config.js
+++ b/vp-docs/.vuepress/config.js
@@ -54,6 +54,7 @@ module.exports = {
           children: [
             '/guide/style-configuration/',
             '/guide/style-configuration/style-classes',
+            '/guide/style-configuration/sass',
           ]
         },
       ],

--- a/vp-docs/guide/style-configuration/sass.md
+++ b/vp-docs/guide/style-configuration/sass.md
@@ -1,0 +1,17 @@
+# Sass
+
+Vue-Good-Table's styling is written in Sass. The source files are made available as part of the npm dependency.
+
+**Vue-Good-Table's root Sass file:**
+
+```scss
+@import "../node_modules/vue-good-table/src/styles/style.scss";
+```
+
+Vue-Good-Table has an optional feature to filter a column based on a multi-select dropdown. We use Vue-Select for this feature.
+
+**Vue-Select's root Sass file**
+
+```scss
+@import "../node_modules/vue-select/src/scss/vue-select.scss";
+```


### PR DESCRIPTION
Fixes #672

This moves the V-Select styles to the component level to allow it's import to be resolved without breaking anyone's custom Sass build system.