### PR TITLE
fix: highlighting should work even when striped style is applied

### DIFF
--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -15,7 +15,7 @@ table.vgt-table{
   & tr.clickable {
     cursor: pointer;
     &:hover{
-      background-color: $highlight-color !important;
+      background-color: $highlight-color;
     }
   }
 }

--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -15,7 +15,7 @@ table.vgt-table{
   & tr.clickable {
     cursor: pointer;
     &:hover{
-      background-color: $highlight-color;
+      background-color: $highlight-color !important;
     }
   }
 }

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,3 +1,5 @@
+@import './striped';
+
 // base table styles
 @import './variables';
 @import './utils';
@@ -9,7 +11,6 @@
 
 // table enhancements
 @import './bordered';
-@import './striped';
 @import './rtl';
 @import './condensed';
 


### PR DESCRIPTION
#### Description
When using the `striped` class, the highlight only works on non-striped rows. 

#### Fix
Probably not the best way to fix this, but if the hover styling is `!important`, then it does not get overridden by the `_striped.scss` styling. I guess one should play with the selectors and their order instead, but this fix seems to work fine.