### PR TITLE
Add feature to enable checking all checkboxes of a grouped table

### DIFF
--- a/dev/grouped-table.vue
+++ b/dev/grouped-table.vue
@@ -6,7 +6,10 @@
     :columns="columns"
     :rows="rows"
     :line-numbers="true"
-    :select-options="{enabled: true}"
+    :select-options="{
+      enabled: true,
+      selectAllByGroup: true
+    }"
     @on-select-all="onSelectAll"
     @on-search="onSelectAll"
     @on-row-mouseenter="onMouseover"

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1560,7 +1560,9 @@ export default {
         this.selectAllByPage = selectAllByPage;
       }
 
-      this.selectAllByGroup = Boolean(selectAllByGroup);
+      if (typeof selectAllByGroup === 'boolean') {
+        this.selectAllByGroup = selectAllByGroup;
+      }
 
       if (typeof disableSelectInfo === 'boolean') {
         this.disableSelectInfo = disableSelectInfo;

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -163,7 +163,6 @@
               :get-classes="getClasses"
               :full-colspan="fullColspan"
               :groupIndex="index"
-              :groupOptions="groupOptions"
               @on-select-group-change="toggleSelectGroup($event, headerRow)"
             >
               <template
@@ -245,7 +244,6 @@
               :get-classes="getClasses"
               :full-colspan="fullColspan"
               :groupIndex="index"
-              :groupOptions="groupOptions"
               @on-select-group-change="toggleSelectGroup($event, headerRow)"
             >
               <template
@@ -876,7 +874,7 @@ export default {
               hRow = cloneDeep(hRow);
               hRow.children = [];
               reconstructedRows.push(hRow);
-        }
+            }
           }
           hRow.children.push(flatRow);
         }

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -876,7 +876,7 @@ export default {
               hRow = cloneDeep(hRow);
               hRow.children = [];
               reconstructedRows.push(hRow);
-            }
+        }
           }
           hRow.children.push(flatRow);
         }
@@ -1385,6 +1385,12 @@ export default {
     handleGrouped(originalRows) {
       each(originalRows, (headerRow, i) => {
         headerRow.vgt_header_id = i;
+        if (
+          this.groupOptions.maintainExpanded &&
+          this.expandedRowKeys.has(headerRow[this.groupOptions.rowKey])
+        ) {
+          this.$set(headerRow, 'vgtIsExpanded', true);
+        }
         each(headerRow.children, (childRow) => {
           childRow.vgt_id = i;
         });

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -155,12 +155,16 @@
               :columns="columns"
               :line-numbers="lineNumbers"
               :selectable="selectable"
+              :select-all-by-group="selectAllByGroup"
               :collapsable="groupOptions.collapsable"
               :collect-formatted="collectFormatted"
               :formatted-row="formattedRow"
               :class="getRowStyleClass(headerRow)"
               :get-classes="getClasses"
               :full-colspan="fullColspan"
+              :groupIndex="index"
+              :groupOptions="groupOptions"
+              @on-select-group-change="toggleSelectGroup($event, headerRow)"
             >
               <template
                 v-if="hasHeaderRowTemplate"
@@ -235,10 +239,14 @@
               :columns="columns"
               :line-numbers="lineNumbers"
               :selectable="selectable"
+              :select-all-by-group="selectAllByGroup"
               :collect-formatted="collectFormatted"
               :formatted-row="formattedRow"
               :get-classes="getClasses"
               :full-colspan="fullColspan"
+              :groupIndex="index"
+              :groupOptions="groupOptions"
+              @on-select-group-change="toggleSelectGroup($event, headerRow)"
             >
               <template
                 v-if="hasHeaderRowTemplate"
@@ -360,6 +368,7 @@ export default {
           selectionText: 'rows selected',
           clearSelectionText: 'clear',
           disableSelectInfo: false,
+          selectAllByGroup: false,
         };
       },
     },
@@ -1011,6 +1020,12 @@ export default {
       this.emitSelectedRows();
     },
 
+    toggleSelectGroup(event, headerRow) {
+      each(headerRow.children, (row) => {
+        this.$set(row, 'vgtSelected', event.checked);
+      });
+    },
+
     changePage(value) {
       if (this.paginationOptions.enabled) {
         let paginationWidget = this.$refs.paginationBottom;
@@ -1524,6 +1539,7 @@ export default {
         selectOnCheckboxOnly,
         selectAllByPage,
         disableSelectInfo,
+        selectAllByGroup,
       } = this.selectOptions;
 
       if (typeof enabled === 'boolean') {
@@ -1537,6 +1553,8 @@ export default {
       if (typeof selectAllByPage === 'boolean') {
         this.selectAllByPage = selectAllByPage;
       }
+
+      this.selectAllByGroup = Boolean(selectAllByGroup);
 
       if (typeof disableSelectInfo === 'boolean') {
         this.disableSelectInfo = disableSelectInfo;

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -5,6 +5,17 @@
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan"
     @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
+    <template v-if="selectAllByGroup">
+      <slot name="table-header-group-select"
+        :columns="columns"
+        :row="headerRow"
+      >
+        <input
+          type="checkbox"
+          :checked="allSelected"
+          @change="toggleSelectGroup($event)" />
+      </slot>
+    </template>
     <span v-if="collapsable" class="triangle" :class="{ 'expand': headerRow.vgtIsExpanded }"></span>
     <slot
       :row="headerRow"
@@ -22,7 +33,20 @@
     v-if="headerRow.mode !== 'span' && lineNumbers"></th>
   <th
     class="vgt-row-header"
-    v-if="headerRow.mode !== 'span' && selectable"></th>
+    v-if="headerRow.mode !== 'span' && selectable">
+    <template v-if="selectAllByGroup"
+    >
+      <slot name="table-header-group-select"
+        :columns="columns"
+        :row="headerRow"
+      >
+        <input
+          type="checkbox"
+          :checked="allSelected"
+          @change="toggleSelectGroup($event)" />
+      </slot>
+    </template>
+  </th>
   <th
     v-if="headerRow.mode !== 'span' && !column.hidden"
     v-for="(column, i) in columns"
@@ -62,6 +86,9 @@ export default {
     selectable: {
       type: Boolean,
     },
+    selectAllByGroup: {
+      type: Boolean
+    },
     collapsable: {
       type: [Boolean, Number],
       default: false,
@@ -78,12 +105,22 @@ export default {
     fullColspan: {
       type: Number,
     },
+    groupIndex: {
+      type: Number
+    },
+    groupOptions: {
+      type: Object
+    }
   },
   data() {
     return {
     };
   },
   computed: {
+    allSelected() {
+      const { headerRow, groupChildObject } = this;
+      return headerRow.children.filter((row) => row.vgtSelected).length === headerRow.children.length;
+    }
   },
   methods: {
     columnCollapsable(currentIndex) {
@@ -92,7 +129,13 @@ export default {
       }
       return currentIndex === this.collapsable;
     },
+    toggleSelectGroup(event) {
+      this.$emit('on-select-group-change', {
+        groupIndex: this.groupIndex, checked: event.target.checked
+      });
+    }
   },
+  
   mounted() {
   },
   components: {

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -110,9 +110,6 @@ export default {
     groupIndex: {
       type: Number
     },
-    groupOptions: {
-      type: Object
-    }
   },
   data() {
     return {

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -4,7 +4,7 @@
     v-if="headerRow.mode === 'span'"
     class="vgt-left-align vgt-row-header"
     :colspan="fullColspan"
-    @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
+    >
     <template v-if="selectAllByGroup">
       <slot name="table-header-group-select"
         :columns="columns"
@@ -16,16 +16,18 @@
           @change="toggleSelectGroup($event)" />
       </slot>
     </template>
-    <span v-if="collapsable" class="triangle" :class="{ 'expand': headerRow.vgtIsExpanded }"></span>
-    <slot
-      :row="headerRow"
-      name="table-header-row">
-      <span v-if="headerRow.html" v-html="headerRow.label">
-      </span>
-      <span v-else>
-        {{ headerRow.label }}
-      </span>
-    </slot>
+    <span @click="collapsable ? $emit('vgtExpand', !headerRow.vgtIsExpanded) : () => {}">
+      <span v-if="collapsable" class="triangle" :class="{ 'expand': headerRow.vgtIsExpanded }"></span>
+        <slot
+        :row="headerRow"
+        name="table-header-row">
+        <span v-if="headerRow.html" v-html="headerRow.label">
+        </span>
+        <span v-else>
+          {{ headerRow.label }}
+        </span>
+      </slot>
+    </span>
   </th>
   <!-- if the mode is not span, we display every column -->
   <th

--- a/vp-docs/guide/advanced/checkbox-table.md
+++ b/vp-docs/guide/advanced/checkbox-table.md
@@ -20,6 +20,7 @@ Object containing select options
     selectionText: 'rows selected',
     clearSelectionText: 'clear',
     disableSelectInfo: true, // disable the select info panel on top
+    selectAllByGroup: true, // when used in combination with a grouped table, add a checkbox in the header row to check/uncheck the entire group
   }">
 ```
 

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -178,5 +178,24 @@ this.$refs.myCustomTable.expandAll();
 this.$refs.myCustomTable.collapseAll();
 ```
 
+### Maintaining Expanded Rows
+
+If you make alterations to the data being passed into the rows on the table, such as adding or removing a row, all of your groupings will be collapsed by default. 
+Inside of `groupOptions`, add an attribute of `maintainExpanded: true` so that the expanded rows will stay expanded after 
+changes to the row data. Additionally you must provide the `rowKey` attribute as a string. The `rowKey` shoud be a field on the row
+that can be used for a unique identifier, such as 'id'.  
+
+```vue
+<vue-good-table
+  :columns="columns"
+  :rows="rows"
+  :groupOptions="{
+    enabled: true,
+    collapsable: true,
+    maintainExpanded: true,
+    rowKey: 'id'
+  }"
+/>
+```
 * **Live Demo:** https://jsfiddle.net/nb6fcqs7
 

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -179,3 +179,4 @@ this.$refs.myCustomTable.collapseAll();
 ```
 
 * **Live Demo:** https://jsfiddle.net/nb6fcqs7
+

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -178,24 +178,4 @@ this.$refs.myCustomTable.expandAll();
 this.$refs.myCustomTable.collapseAll();
 ```
 
-### Maintaining Expanded Rows
-
-If you make alterations to the data being passed into the rows on the table, such as adding or removing a row, all of your groupings will be collapsed by default. 
-Inside of `groupOptions`, add an attribute of `maintainExpanded: true` so that the expanded rows will stay expanded after 
-changes to the row data. Additionally you must provide the `rowKey` attribute as a string. The `rowKey` shoud be a field on the row
-that can be used for a unique identifier, such as 'id'.  
-
-```vue
-<vue-good-table
-  :columns="columns"
-  :rows="rows"
-  :groupOptions="{
-    enabled: true,
-    collapsable: true,
-    maintainExpanded: true,
-    rowKey: 'id'
-  }"
-/>
-```
 * **Live Demo:** https://jsfiddle.net/nb6fcqs7
-


### PR DESCRIPTION
Add feature to enable checking all checkboxes of a grouped table's children.

The checkbox is available in span/non-span mode in the vgt-header-row.

![image](https://user-images.githubusercontent.com/1331394/80610165-4db99b80-8a39-11ea-82c1-6509bc2a025e.png)
