### PR TITLE
Add rowKey option and documentation

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -150,7 +150,7 @@
             <!-- if group row header is at the top -->
             <vgt-header-row
               v-if="groupHeaderOnTop"
-              @vgtExpand="toggleExpand(headerRow.vgt_header_id)"
+              @vgtExpand="toggleExpand(headerRow[rowKeyField])"
               :header-row="headerRow"
               :columns="columns"
               :line-numbers="lineNumbers"
@@ -347,6 +347,7 @@ export default {
         return {
           enabled: false,
           collapsable: false,
+          rowKey: null
         };
       },
     },
@@ -528,6 +529,10 @@ export default {
         overflow: 'scroll-y',
         maxHeight: this.maxHeight ? this.maxHeight : 'auto',
       };
+    },
+
+    rowKeyField() {
+      return this.groupOptions.rowKey || 'vgt_header_id';
     },
 
     hasHeaderRowTemplate() {
@@ -914,22 +919,23 @@ export default {
     //* to maintain it when sorting/filtering
     handleExpanded(headerRow) {
       if (this.maintainExpanded &&
-        this.expandedRowKeys.has(headerRow.vgt_header_id)) {
+        this.expandedRowKeys.has(headerRow[this.rowKeyField])) {
         this.$set(headerRow, 'vgtIsExpanded', true);
       } else {
         this.$set(headerRow, 'vgtIsExpanded', false);
       }
     },
-    toggleExpand(index) {
-      const headerRow = this.filteredRows.find(r => r.vgt_header_id === index);
+    toggleExpand(id) {
+      console.log(id);
+      const headerRow = this.filteredRows.find(r => r[this.rowKeyField] === id);
       if (headerRow) {
         this.$set(headerRow, 'vgtIsExpanded', !headerRow.vgtIsExpanded);
       }
       if (this.maintainExpanded
         && headerRow.vgtIsExpanded) {
-        this.expandedRowKeys.add(headerRow.vgt_header_id);
+        this.expandedRowKeys.add(headerRow[this.rowKeyField]);
       } else {
-        this.expandedRowKeys.delete(headerRow.vgt_header_id);
+        this.expandedRowKeys.delete(headerRow[this.rowKeyField]);
       }
     },
 
@@ -937,7 +943,7 @@ export default {
       this.filteredRows.forEach((row) => {
         this.$set(row, 'vgtIsExpanded', true);
         if (this.maintainExpanded) {
-          this.expandedRowKeys.add(row.vgt_header_id);
+          this.expandedRowKeys.add(row[this.rowKeyField]);
         }
       });
     },

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -926,7 +926,6 @@ export default {
       }
     },
     toggleExpand(id) {
-      console.log(id);
       const headerRow = this.filteredRows.find(r => r[this.rowKeyField] === id);
       if (headerRow) {
         this.$set(headerRow, 'vgtIsExpanded', !headerRow.vgtIsExpanded);

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -156,6 +156,9 @@ In this case header row expects a value for each column
 
 To allow the row to collapse and expand you can use the groupOption "collapsable". You can either pass in a boolean or a number.
 If `collapsable` is set to `true` then it will default to making the first column collapsable. Alternatively, you can specify the column index number.
+If you only add new rows to your table at the end, then the expanded or collapsed state of your rows will be maintained. 
+However if you need to insert rows before the last one, you can pass in `rowKey` inside of `groupOptions` with a unique identifier for your rows. 
+The expanded and collapsed state will then be maintained. 
 ```html
 <vue-good-table
   ref="myCustomTable"
@@ -163,6 +166,7 @@ If `collapsable` is set to `true` then it will default to making the first colum
   :rows="rows"
   :group-options="{
     enabled: true,
+    rowKey="id"
     collapsable: true // or column index
   }"
 >


### PR DESCRIPTION
This solves https://github.com/xaksis/vue-good-table/issues/715#issue-627385236

If you add data rows only to the end of your table, the latest release of vue-good-table will maintain the expanded state of all rows, and not collapse them automatically any time the data changes. But if you add a row in the middle of the table, the one that was added is automatically expanded and the one that is bumped down gets collapsed. 

**Proposed Solution**
To the `groupOptions`, add an optional `rowKey` attribute, which is used to provide a unique identifier for the row data. If provided, that key will be used to track expanded state instead of the `vgt_header_id`.