### PR TITLE
Fix console warnings on docs build

### DIFF
--- a/src/components/types/date.js
+++ b/src/components/types/date.js
@@ -25,7 +25,7 @@ date.compare = function (x, y, column) {
 };
 
 date.format = function (v, column) {
-  if (v === undefined || v === null) return '';
+  if (v === undefined || v === null || v === '') return '';
   // convert to date
   const date = parse(v, column.dateInputFormat, new Date());
   if (isValid(date)) {


### PR DESCRIPTION
When I ran `npm run docs:build` I got a bunch of `Not a valid date: ""` warnings. Not sure where they were coming from, but adding this line got rid of them. probably should look into this more deeply before merging it to see what the actual root cause is.