### PR TITLE
Fixed header resize observer

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -64,9 +64,8 @@
           </slot>
         </div>
       </div>
-      <div class="vgt-fixed-header">
+      <div class="vgt-fixed-header" v-if="fixedHeader">
         <table
-          v-if="fixedHeader"
           :class="tableStyleClasses"
         >
           <!-- Table header -->
@@ -176,57 +175,57 @@
               </template>
             </vgt-header-row>
             <!-- normal rows here. we loop over all rows -->
-            <tr
-              v-if="groupOptions.collapsable ? headerRow.vgtIsExpanded : true"
-              v-for="(row, index) in headerRow.children"
-              :key="row.originalIndex"
-              :class="getRowStyleClass(row)"
-              @mouseenter="onMouseenter(row, index)"
-              @mouseleave="onMouseleave(row, index)"
-              @dblclick="onRowDoubleClicked(row, index, $event)"
-              @click="onRowClicked(row, index, $event)"
-              @auxclick="onRowAuxClicked(row, index, $event)">
-              <th
-                v-if="lineNumbers"
-                class="line-numbers"
-              >
-                {{ getCurrentIndex(index) }}
-              </th>
-              <th
-                v-if="selectable"
-                @click.stop="onCheckboxClicked(row, index, $event)"
-                class="vgt-checkbox-col"
-              >
-                <input
-                  type="checkbox"
-                  :checked="row.vgtSelected"
-                />
-              </th>
-              <td
-                @click="onCellClicked(row, column, index, $event)"
-                v-for="(column, i) in columns"
-                :key="i"
-                :class="getClasses(i, 'td', row)"
-                v-if="!column.hidden && column.field"
-              >
-                <slot
-                  name="table-row"
-                  :row="row"
-                  :column="column"
-                  :formattedRow="formattedRow(row)"
-                  :index="index"
+            <template v-if="groupOptions.collapsable ? headerRow.vgtIsExpanded : true">
+              <tr
+                v-for="(row, index) in headerRow.children"
+                :key="row.originalIndex"
+                :class="getRowStyleClass(row)"
+                @mouseenter="onMouseenter(row, index)"
+                @mouseleave="onMouseleave(row, index)"
+                @dblclick="onRowDoubleClicked(row, index, $event)"
+                @click="onRowClicked(row, index, $event)"
+                @auxclick="onRowAuxClicked(row, index, $event)">
+                <th
+                  v-if="lineNumbers"
+                  class="line-numbers"
                 >
-                  <span v-if="!column.html">
-                    {{ collectFormatted(row, column) }}
-                  </span>
-                  <span
-                    v-if="column.html"
-                    v-html="collect(row, column.field)"
+                  {{ getCurrentIndex(index) }}
+                </th>
+                <th
+                  v-if="selectable"
+                  @click.stop="onCheckboxClicked(row, index, $event)"
+                  class="vgt-checkbox-col"
+                >
+                  <input
+                    type="checkbox"
+                    :checked="row.vgtSelected"
+                  />
+                </th>
+                <td
+                  @click="onCellClicked(row, column, index, $event)"
+                  v-for="(column, i) in computedColumns"
+                  :key="i"
+                  :class="getClasses(i, 'td', row)"
+                >
+                  <slot
+                    name="table-row"
+                    :row="row"
+                    :column="column"
+                    :formattedRow="formattedRow(row)"
+                    :index="index"
                   >
-                  </span>
-                </slot>
-              </td>
-            </tr>
+                    <span v-if="!column.html">
+                      {{ collectFormatted(row, column) }}
+                    </span>
+                    <span
+                      v-if="column.html"
+                      v-html="collect(row, column.field)"
+                    >
+                    </span>
+                  </slot>
+                </td>
+              </tr>
+            </template>
             <!-- if group row header is at the bottom -->
             <vgt-header-row
               v-if="groupHeaderOnBottom"
@@ -334,8 +333,8 @@ export default {
     mode: { default: 'local' }, // could be remote
     totalRows: {}, // required if mode = 'remote'
     styleClass: { default: 'vgt-table bordered' },
-    columns: {},
-    rows: {},
+    columns: { type: Array },
+    rows: { type: Array },
     lineNumbers: { default: false },
     responsive: { default: true },
     rtl: { default: false },
@@ -514,6 +513,16 @@ export default {
   },
 
   computed: {
+    computedColumns () {
+      let renderedColumns = [];
+      for (const column of this.columns) {
+        if (!column.hidden && column.field) {
+          renderedColumns.push(column);
+        }
+      }
+      return renderedColumns;
+    },
+
     hasFooterSlot() {
       return !!this.$slots['table-actions-bottom'];
     },

--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -9,12 +9,11 @@
         :indeterminate.prop="allSelectedIndeterminate"
         @change="toggleSelectAll" />
     </th>
-    <th v-for="(column, index) in columns"
+    <th v-for="(column, index) in renderedColumns"
       :key="index"
       @click="sort($event, column)"
       :class="getHeaderClasses(column, index)"
-      :style="columnStyles[index]"
-      v-if="!column.hidden">
+      :style="columnStyles[index]">
       <slot name="table-column" :column="column">
         <span>{{column.label}}</span>
       </slot>
@@ -122,9 +121,19 @@ export default {
       lineNumberThStyle: {},
       columnStyles: [],
       sorts: [],
+      ro: null
     };
   },
   computed: {
+    renderedColumns () {
+      let renderedColumns = [];
+      this.columns.forEach((column) => {
+        if (!column.hidden) {
+          renderedColumns.push(column);
+        }
+      });
+      return renderedColumns;
+    }
   },
   methods: {
     reset() {
@@ -228,10 +237,15 @@ export default {
     },
   },
   mounted() {
-    window.addEventListener('resize', this.setColumnStyles);
+    this.$nextTick(() => {
+      this.ro = new ResizeObserver(() => {
+          this.setColumnStyles();
+      });
+      this.ro.observe(this.$parent.$el);
+    });
   },
   beforeDestroy() {
-    window.removeEventListener('resize', this.setColumnStyles);
+    this.ro.disconnect();
   },
   components: {
     'vgt-filter-row': VgtFilterRow,

--- a/src/styles/_wrap.scss
+++ b/src/styles/_wrap.scss
@@ -4,6 +4,5 @@
 .vgt-fixed-header{
   position: absolute;
   z-index: 10;
-  width: 100%;
   overflow-x: auto;
 }


### PR DESCRIPTION
I was often having issues with the fixed header overlapping my scrollbar. I did two things to fix this. First, I removed the width: 100% rule from the CSS. Secondly, I set the function that gets the fixed header columns to recalculate their size to trigger not on a window resize, but on a resize observer of the parent element instead. This way if the page layout changes, the header columns will resize even if the page doesn't. As a demo, wrap the vue-good-table element in a div. In your Dev Tools, resize that div. Before this change, the fixed header columns don't resize.

In addition to the above, I fixed the Vetur warnings that a v-if should not be used with a v-for, that instead the v-for should be used on a computed value with the filtered input. I either did the above suggestion, or in one case, I moved a v-if to a template wrapper element.