### PR TITLE
Fixed header now has a resize observer for primary column headers

### DIFF
--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -133,6 +133,7 @@ export default {
       lineNumberThStyle: {},
       columnStyles: [],
       sorts: [],
+      ro: null
     };
   },
   computed: {
@@ -239,17 +240,28 @@ export default {
     },
   },
   mounted() {
-    window.addEventListener('resize', this.setColumnStyles);
+    this.$nextTick(() => {
+      // We're going to watch the parent element for resize events, and calculate column widths if it changes
+      this.ro = new ResizeObserver(() => {
+          this.setColumnStyles();
+      });
+      this.ro.observe(this.$parent.$el);
+      
+      // If this is a fixed-header table, we want to observe each column header from the non-fixed header.
+      // You can imagine two columns swapping widths, which wouldn't cause the above to trigger.
+      // This gets the first tr element of the primary table header, and iterates through its children (the th elements)
+      if (this.tableRef) {
+        Array.from(this.$parent.$refs['table-header-primary'].$el.children[0].children).forEach((header) => {
+          this.ro.observe(header);
+        })
+      }
+    });
   },
   beforeDestroy() {
-    window.removeEventListener('resize', this.setColumnStyles);
+    this.ro.disconnect();
   },
   components: {
     'vgt-filter-row': VgtFilterRow,
   },
 };
 </script>
-
-<style lang="scss" scoped>
-
-</style>

--- a/src/styles/_wrap.scss
+++ b/src/styles/_wrap.scss
@@ -4,6 +4,5 @@
 .vgt-fixed-header{
   position: absolute;
   z-index: 10;
-  width: 100%;
   overflow-x: auto;
 }


### PR DESCRIPTION
Previously, column widths were updated only on a window resize event. This ticket makes two changes to that behavior:

1. If the page layout changes without a window resize, columns weren't getting updated. As an example, put a wrapper div around the component. Now change the width on that wrapper. The column sizes don't get updated, since the window isn't resizing.
2. If there is a fixed header, we also watch each th in the primary table header for a resize. Previously, if you were to inline table-layout: fixed onto the primary table, the fixed header wouldn't get updated, since the wrapper element didn't change sizes, just the column widths. Now column headers are watched for resize changes, and the fixed header updates accordingly if they change.

This addresses #697