### PR TITLE
update both sides of pagination widget during changes

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1043,17 +1043,18 @@ export default {
     },
 
     changePage(value) {
-      if (this.paginationOptions.enabled) {
-        let paginationWidget = this.$refs.paginationBottom;
-        if (this.paginationOptions.position === 'top') {
-          paginationWidget = this.$refs.paginationTop;
+      let { enabled, position } = this.paginationOptions
+      let { paginationBottom, paginationTop } = this.$refs
+      if (enabled) {
+        if ((position === 'top' || position === 'both') && paginationTop) {
+          paginationTop.currentPage = value
         }
-        if (paginationWidget) {
-          paginationWidget.currentPage = value;
-          // we also need to set the currentPage
-          // for table.
-          this.currentPage = value;
+        if ((position === 'bottom' || position === 'both') && paginationBottom) {
+          paginationBottom.currentPage = value
         }
+        // we also need to set the currentPage
+        // for table.
+        this.currentPage = value;
       }
     },
 
@@ -1077,6 +1078,15 @@ export default {
 
     perPageChanged(pagination) {
       this.currentPerPage = pagination.currentPerPage;
+      // ensure that both sides of pagination are in agreement
+      // this fixes changes during position = 'both'
+      let paginationPosition = this.paginationOptions.position
+      if (this.$refs.paginationTop && (paginationPosition === 'top' || paginationPosition === 'both')) {
+        this.$refs.paginationTop.currentPerPage = this.currentPerPage
+      }
+      if (this.$refs.paginationBottom && (paginationPosition === 'bottom' || paginationPosition === 'both')) {
+        this.$refs.paginationBottom.currentPerPage = this.currentPerPage
+      }
       //* update perPage also
       const perPageChangedEvent = this.pageChangedEvent();
       this.$emit('on-per-page-change', perPageChangedEvent);


### PR DESCRIPTION
This is a fix I made for https://github.com/xaksis/vue-good-table/issues/560 where the top/bottom pagination widgets didn't match up.

it hooks into the changePage and perPageChanged events and ensures that either or both pagination widgets are set appropriately during these changes.

Thanks for the all the work you've put in the library, this was the only thing that was bugging me about it so I decided to fix it.