### PR TITLE
Replace deprecated slot syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,7 @@ vue-good-table also supports dynamic td templates where you dictate how to displ
 <vue-good-table
   :columns="columns"
   :rows="rows">
-  <template slot="table-row" slot-scope="props">
+  <template v-slot:table-row="props">
     <span v-if="props.column.field == 'age'">
       age: {{props.row.age}}
     </span>
@@ -1143,7 +1143,7 @@ Sometimes you might want to use custom column formatting. You can do that in the
 <vue-good-table
   :columns="columns"
   :rows="rows">
-  <template slot="table-column" slot-scope="props">
+  <template v-slot:table-column="props">
      <span v-if="props.column.label =='Name'">
         <i class="fa fa-address-book"></i> {{props.column.label}}
      </span>

--- a/dev/grouped-table.vue
+++ b/dev/grouped-table.vue
@@ -28,7 +28,7 @@
     styleClass="vgt-table condensed bordered"
     ref="groupedTable"
   >
-    <!-- <template slot="table-header-row" slot-scope="props">
+    <!-- <template v-slot:table-header-row="props">
       <span v-if="props.row.mode === 'span'">
         My header label is - <strong>{{ props.row.label }}</strong>
       </span>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -90,8 +90,7 @@
             :table-ref="$refs.table"
           >
             <template
-              slot="table-column"
-              slot-scope="props"
+              v-slot:table-column="props"
             >
               <slot
                 name="table-column"
@@ -130,8 +129,7 @@
             :searchEnabled="searchEnabled"
           >
             <template
-              slot="table-column"
-              slot-scope="props"
+              v-slot:table-column="props"
             >
               <slot
                 name="table-column"
@@ -141,8 +139,7 @@
               </slot>
             </template>
             <template
-              slot="column-filter"
-              slot-scope="props"
+              v-slot:column-filter="props"
             >
               <slot
                 name="column-filter"
@@ -177,8 +174,7 @@
             >
               <template
                 v-if="hasHeaderRowTemplate"
-                slot="table-header-row"
-                slot-scope="props"
+                v-slot:table-header-row="props"
               >
                 <slot
                   name="table-header-row"
@@ -259,8 +255,7 @@
             >
               <template
                 v-if="hasHeaderRowTemplate"
-                slot="table-header-row"
-                slot-scope="props"
+                v-slot:table-header-row="props"
               >
                 <slot
                   name="table-header-row"

--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -31,8 +31,7 @@
     :mode="mode"
     :typed-columns="typedColumns">
       <template
-        slot="column-filter"
-        slot-scope="props"
+        v-slot:column-filter="props"
       >
         <slot
           name="column-filter"

--- a/vp-docs/.vuepress/components/before-after-columns.vue
+++ b/vp-docs/.vuepress/components/before-after-columns.vue
@@ -3,7 +3,7 @@
   <vue-good-table
     :columns="columns"
     :rows="rows">
-    <template slot="table-row" slot-scope="props">
+    <template v-slot:table-row="props">
       <span v-if="props.column.field == 'before'">
         before
       </span>

--- a/vp-docs/.vuepress/components/custom-row.vue
+++ b/vp-docs/.vuepress/components/custom-row.vue
@@ -3,7 +3,7 @@
   <vue-good-table
     :columns="columns"
     :rows="rows">
-    <template slot="table-row" slot-scope="props">
+    <template v-slot:table-row="props">
       <span v-if="props.column.field == 'age'">
         <span style="font-weight: bold; color: blue;">{{props.row.age}}</span> 
       </span>

--- a/vp-docs/.vuepress/components/grouped-custom-span.vue
+++ b/vp-docs/.vuepress/components/grouped-custom-span.vue
@@ -7,7 +7,7 @@
     :search-options="{ 
       enabled: true,
     }">
-    <template slot="table-header-row" slot-scope="props">
+    <template v-slot:table-header-row="props">
       <span class="my-fancy-class">
         {{ props.row.label }}
       </span>

--- a/vp-docs/.vuepress/components/grouped-custom.vue
+++ b/vp-docs/.vuepress/components/grouped-custom.vue
@@ -7,7 +7,7 @@
     :search-options="{ 
       enabled: true,
     }">
-    <template slot="table-header-row" slot-scope="props">
+    <template v-slot:table-header-row="props">
       <span v-if="props.column.field == 'action'">
         <button class="fancy-btn" @click="showAlert(props)">Action</button>
       </span>

--- a/vp-docs/guide/advanced/README.md
+++ b/vp-docs/guide/advanced/README.md
@@ -7,7 +7,7 @@ Sometimes you might want to customize exactly how rows are displayed in a table.
 <vue-good-table
   :columns="columns"
   :rows="rows">
-  <template slot="table-row" slot-scope="props">
+  <template v-slot:table-row="props">
     <span v-if="props.column.field == 'age'">
       <span style="font-weight: bold; color: blue;">{{props.row.age}}</span> 
     </span>
@@ -37,7 +37,7 @@ Sometimes you might want to add columns to the table that are not part of your r
 <vue-good-table
   :columns="columns"
   :rows="rows">
-  <template slot="table-row" slot-scope="props">
+  <template v-slot:table-row="props">
     <span v-if="props.column.field == 'before'">
       before
     </span>
@@ -72,7 +72,7 @@ Sometimes you might want to customize column headers. You can do that in the fol
 <vue-good-table
   :columns="columns"
   :rows="rows">
-  <template slot="table-column" slot-scope="props">
+  <template v-slot:table-column="props">
      <span v-if="props.column.label =='Name'">
         <i class="fa fa-address-book"></i> {{props.column.label}}
      </span>
@@ -89,7 +89,7 @@ Sometimes you might want a custom filter. You can do that in the following way:
 <vue-good-table
   :columns="columns"
   :rows="rows">
-  <template slot="column-filter" slot-scope="props">
+  <template v-slot:column-filter="props">
     <my-custom-filter
       v-if="props.column.filterOptions.customFilter"       
       @input="handleCustomFilter"/>
@@ -127,7 +127,7 @@ You can also provide a function to `formatValue` inside of `filterOptions` to tr
 <vue-good-table
   :columns="columns"
   :rows="rows">
-  <template slot="column-filter" slot-scope="{ column, updateFilters }">
+  <template v-slot:column-filter="{ column, updateFilters }">
     <my-custom-filter
       v-if="column.filterOptions.customFilter"
       @input="(value) => updateFilters(column, value)"/>
@@ -217,7 +217,7 @@ Sometimes you might want to customize the pagination. You can do that in the fol
   :columns="columns"
   :rows="rows"
   :pagination-options="{enabled: true}">
-  <template slot="pagination-bottom" slot-scope="props">
+  <template v-slot:pagination-bottom="props">
     <custom-pagination
       :total="props.total"
       :pageChanged="props.pageChanged"

--- a/vp-docs/guide/advanced/grouped-table.md
+++ b/vp-docs/guide/advanced/grouped-table.md
@@ -109,7 +109,7 @@ In this case, the header row spans across all columns
     headerPosition: 'top'
   }"
 >
-  <template slot="table-header-row" slot-scope="props">
+  <template v-slot:table-header-row="props">
     <span class="my-fancy-class">
       {{ props.row.label }}
     </span>
@@ -132,7 +132,7 @@ In this case header row expects a value for each column
     headerPosition: 'top'
   }"
 >
-  <template slot="table-header-row" slot-scope="props">
+  <template v-slot:table-header-row="props">
     <span v-if="props.column.field == 'action'">
       <button class="fancy-btn">Action</button>
     </span>


### PR DESCRIPTION
I used search and replace with the regex:
` slot="([^"]+)"\n?\s+slot-scope="([^"]+)"`
 to replace with:
 ` v-slot:$1="$2"`
everywhere except for `docs/*` and `dist/*`.

fixes #700