### PR TITLE
should fix issue 660

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
+
 .DS_Store
 npm-debug.log
 node_modules/

--- a/src/components/VgtFilterRow.vue
+++ b/src/components/VgtFilterRow.vue
@@ -15,6 +15,7 @@
       <div
         v-if="isFilterable(column)">
         <input v-if="!isDropdown(column)"
+          :name="getName(column)"
           type="text"
           class="vgt-input"
           :placeholder="getPlaceholder(column)"
@@ -24,6 +25,7 @@
 
         <!-- options are a list of primitives -->
         <select v-if="isDropdownArray(column)"
+          :name="getName(column)"
           class="vgt-select"
           :value="columnFilters[column.field]"
           @change="updateFilters(column, $event.target.value)">
@@ -38,6 +40,7 @@
 
         <!-- options are a list of objects with text and value -->
         <select v-if="isDropdownObjects(column)"
+          :name="getName(column)"
           class="vgt-select"
           :value="columnFilters[column.field]"
           @change="updateFilters(column, $event.target.value, true)">
@@ -132,6 +135,10 @@ export default {
     getPlaceholder(column) {
       const placeholder = (this.isFilterable(column) && column.filterOptions.placeholder) || `Filter ${column.label}`;
       return placeholder;
+    },
+
+    getName(column) {
+      return `vgt-' + ${column.field}`;
     },
 
     updateFiltersOnEnter(column, value) {

--- a/src/components/VgtHeaderRow.vue
+++ b/src/components/VgtHeaderRow.vue
@@ -134,7 +134,7 @@ export default {
       });
     }
   },
-  
+
   mounted() {
   },
   components: {


### PR DESCRIPTION
Add name attribute to filters input with the following pattern :
`` `vgt-${column.field}` ``

Previously, the only way to have access to a specific filter was `'input[placeholder="Search"]'`.
We can now use `'input[name="vgt-field1"]'`, that is a better opotion as "name" attribute should be unique in most cases.

This addresses #660 