### PR TITLE
Fixed issue 459: StyleClass for column filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/.idea
-
 .DS_Store
 npm-debug.log
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
+
 .DS_Store
 npm-debug.log
 node_modules/

--- a/dev/App.vue
+++ b/dev/App.vue
@@ -81,6 +81,7 @@ export default {
           filterOptions: {
             enabled: true,
             filterDropdownItems: ['24', '16', '30'],
+            styleClass: 'class1'
             // filterDropdownItems: [
             //   {
             //     value: 24,

--- a/src/components/VgtFilterRow.vue
+++ b/src/components/VgtFilterRow.vue
@@ -2,9 +2,11 @@
 <tr v-if="hasFilterRow">
   <th v-if="lineNumbers"></th>
   <th v-if="selectable"></th>
-  <th class="filter-th"
+  <th
     v-for="(column, index) in columns" :key="index"
-    v-if="!column.hidden">
+    v-if="!column.hidden"
+    :class="getClasses(column)"
+    >
 
     <slot
         name="column-filter"
@@ -126,6 +128,11 @@ export default {
     isDropdownArray(column) {
       return this.isDropdown(column)
         && typeof column.filterOptions.filterDropdownItems[0] !== 'object';
+    },
+
+    getClasses(column) {
+      const firstClass = 'filter-th';
+      return (column.filterOptions && column.filterOptions.styleClass) ? [firstClass, ...column.filterOptions.styleClass.split(' ')].join(' ') : firstClass;
     },
 
     // get column's defined placeholder or default one

--- a/vp-docs/guide/configuration/column-filter-options.md
+++ b/vp-docs/guide/configuration/column-filter-options.md
@@ -12,6 +12,7 @@ columns: [
     label: 'name',
     field: 'user_name',
     filterOptions: {
+      classStyle: 'class1', // class to be added to the parent th element
   	  enabled: true, // enable filter for this column
       placeholder: 'Filter This Thing', // placeholder for filter input
       filterValue: 'Jane', // initial populated value for this filter
@@ -23,6 +24,11 @@ columns: [
   // ...
 ]
 ```
+
+## classStyle
+
+type: `string`
+Class to be added to the parent th element. You can specify several classes separated by a space.
 
 ## enabled
 

--- a/vp-docs/guide/configuration/column-filter-options.md
+++ b/vp-docs/guide/configuration/column-filter-options.md
@@ -25,7 +25,7 @@ columns: [
 ]
 ```
 
-## classStyle
+## styleClass
 
 type: `string`
 Class to be added to the parent th element. You can specify several classes separated by a space.

--- a/vp-docs/guide/configuration/column-filter-options.md
+++ b/vp-docs/guide/configuration/column-filter-options.md
@@ -12,7 +12,7 @@ columns: [
     label: 'name',
     field: 'user_name',
     filterOptions: {
-      classStyle: 'class1', // class to be added to the parent th element
+	  styleClass: 'class1', // class to be added to the parent th element
   	  enabled: true, // enable filter for this column
       placeholder: 'Filter This Thing', // placeholder for filter input
       filterValue: 'Jane', // initial populated value for this filter


### PR DESCRIPTION
Added the `column.filterOptions.styleClass` option + associated doc.

It should be easier to handle filter styling than using something like this `.vgt-table thead tr:nth-child(2)`

This addresses #459 