### PR TITLE
Show custom filter (column-filter) when header is fixed

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -104,6 +104,16 @@
                 <span>{{props.column.label}}</span>
               </slot>
             </template>
+            <template
+                slot="column-filter"
+                slot-scope="props"
+            >
+              <slot
+                  name="column-filter"
+                  :column="props.column"
+                  :updateFilters="props.updateFilters"
+              ></slot>
+            </template>
           </thead>
         </table>
       </div>


### PR DESCRIPTION
Currently custom column filters are only being shown when the header is not fixed (`<vue-good-table :fixed-header="false">`). This PR also adds custom column filters when the header is fixed.