### PR TITLE
fix wrong pagination on grouped rows

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -691,14 +691,14 @@ export default {
     totalRowCount() {
       let total = 0;
       each(this.processedRows, (headerRow) => {
-        total += headerRow.children ? headerRow.children.length : 0;
+        total += headerRow.children ? headerRow.children.length : 1;
       });
       return total;
     },
     totalPageRowCount() {
       let total = 0;
       each(this.paginated, (headerRow) => {
-        total += headerRow.children ? headerRow.children.length : 0;
+        total += headerRow.children ? headerRow.children.length : 1;
       });
       return total;
     },


### PR DESCRIPTION
Because of the issue mentioned in https://github.com/xaksis/vue-good-table/issues/713#issuecomment-655222816 the pagination is not working properly when using grouped rows.

When including the group row in counting the rows for the pages, this error is resolved.