### PR TITLE
Enable option and event for allowing lazyLoad table data

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -24,6 +24,7 @@
           @last-page="lastPage"
           :perPage="perPage"
           :rtl="rtl"
+          :lazyLoad="lazyLoad"
           :total="totalRows || totalRowCount"
           :mode="paginationMode"
           :nextText="nextText"
@@ -322,6 +323,7 @@
           @last-page="lastPage"
           :perPage="perPage"
           :rtl="rtl"
+          :lazyLoad="lazyLoad"
           :total="totalRows || totalRowCount"
           :mode="paginationMode"
           :nextText="nextText"
@@ -423,7 +425,8 @@ export default {
           perPageDropdownEnabled: true,
           position: 'bottom',
           dropdownAllowAll: true,
-          mode: 'records', // or pages
+          mode: 'records', // or pages,
+          lazyLoad: false,
         };
       },
     },
@@ -486,6 +489,7 @@ export default {
     customRowsPerPageDropdown: [],
     paginateDropdownAllowAll: true,
     paginationMode: 'records',
+    lazyLoad: false,
 
     currentPage: 1,
     currentPerPage: 10,
@@ -1461,6 +1465,7 @@ export default {
         allLabel,
         setCurrentPage,
         mode,
+        lazyLoad,
       } = this.paginationOptions;
 
       if (typeof enabled === 'boolean') {
@@ -1526,6 +1531,10 @@ export default {
         setTimeout(() => {
           this.changePage(setCurrentPage);
         }, 500);
+      }
+
+      if (typeof lazyLoad === 'boolean') {
+        this.lazyLoad = lazyLoad;
       }
     },
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -21,6 +21,7 @@
           ref="paginationTop"
           @page-changed="pageChanged"
           @per-page-changed="perPageChanged"
+          @last-page="lastPage"
           :perPage="perPage"
           :rtl="rtl"
           :total="totalRows || totalRowCount"
@@ -318,6 +319,7 @@
           ref="paginationBottom"
           @page-changed="pageChanged"
           @per-page-changed="perPageChanged"
+          @last-page="lastPage"
           :perPage="perPage"
           :rtl="rtl"
           :total="totalRows || totalRowCount"
@@ -1093,6 +1095,10 @@ export default {
       if (this.mode === 'remote') {
         this.$emit('update:isLoading', true);
       }
+    },
+
+    lastPage(pagination) {
+      this.$emit('on-last-page', pagination);
     },
 
     perPageChanged(pagination) {

--- a/src/components/VgtPagination.vue
+++ b/src/components/VgtPagination.vue
@@ -44,11 +44,11 @@
       </button>
 
       <button
-        v-show="nextIsPossible"
+        v-show="nextIsPossible || lazyLoad"
         type="button"
         aria-controls="vgt-table"
         class="footer__navigation__page-btn"
-        :class="{ disabled: !nextIsPossible }"
+        :class="{ disabled: !nextIsPossible && !lazyLoad }"
         @click.prevent.stop="nextPage">
         <span>{{nextText}}</span>
         <span aria-hidden="true" class="chevron" v-bind:class="{ 'right': !rtl, 'left': rtl }"></span>
@@ -74,6 +74,7 @@ export default {
     customRowsPerPageDropdown: { default() { return []; } },
     paginateDropdownAllowAll: { default: true },
     mode: { default: 'records' },
+    lazyLoad: { default: false },
 
     // text options
     nextText: { default: 'Next' },
@@ -166,6 +167,8 @@ export default {
         this.prevPage = this.currentPage;
         ++this.currentPage;
         this.pageChanged();
+      } else {
+        this.lastPage();
       }
     },
 
@@ -181,6 +184,14 @@ export default {
     // Indicate page changing
     pageChanged() {
       this.$emit('page-changed', {
+        currentPage: this.currentPage,
+        prevPage: this.prevPage,
+      });
+    },
+
+    // Indicate last page reached
+    lastPage() {
+      this.$emit('last-page', {
         currentPage: this.currentPage,
         prevPage: this.prevPage,
       });

--- a/vp-docs/guide/configuration/table-events.md
+++ b/vp-docs/guide/configuration/table-events.md
@@ -128,6 +128,25 @@ event emitted on pagination page change (when pagination is enabled)
    }
  }
  ```
+
+## @on-last-page
+event emitted on pagination last page reached (when pagination is enabled)
+```html
+<vue-good-table
+  :columns="columns"
+  :rows="rows"
+  @on-last-page="onLastPage">
+ ```
+ ```javascript
+ methods: {
+   onLastPage(params) {
+     // params.currentPage - current page that pagination is at
+     // params.prevPage - previous page
+     // params.currentPerPage - number of items per page
+     // params.total - total number of items in the table
+   }
+ }
+ ```
  
 ## @on-per-page-change
 event emitted on per page dropdown change (when pagination is enabled)


### PR DESCRIPTION
We use vue-good-table for a view with a lot of rows. For ex. 40k. And for this we'd like to not always get all data from the db at once. And just load it as the user navigates through the pagination.

For this we need an option that will gives us an event when the last page has been reached, and the user clicks on next.

This PR will allow for such behavior when the pagination option `lazyLoad` is passed.
When the user clicks next, and the last page has been reached. And event is fired named `on-last-page`.

Docs have been updated.

![image](https://user-images.githubusercontent.com/1331394/108593996-8f745380-7377-11eb-9f8e-ec852f3309c7.png)
![image](https://user-images.githubusercontent.com/1331394/108594019-b894e400-7377-11eb-9bd9-dc2da89f218a.png)

For if anyone is curious how we implement this.
We listen on the on-last-page event.
Then we get the next page from db. For ex. next 1000 rows.
We use Vue reactivity to wait for a change in the rows. Then we use $refs to manually move to the next page.
Like: 
```js
this.$refs["my-vgt"].$refs.paginationBottom.currentPage += 1;
this.$refs["my-vgt"].$refs.paginationBottom.pageChanged();
```

It's still WIP. But I plan to add a small component that shows a loading... image, while getting new data from db.