### PR TITLE
Prevent JSON parse error

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1581,7 +1581,9 @@ export default {
     },
 
     initializeSort() {
-      const { enabled, initialSortBy, multipleColumns } = this.sortOptions;
+      const enabled = this.sortOptions.enabled;
+      const multipleColumns = this.sortOptions.multipleColumns;
+      const initialSortBy = this.sortOptions.initialSortBy || {};
       const initSortBy = JSON.parse(JSON.stringify(initialSortBy));
 
       if (typeof enabled === 'boolean') {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1581,10 +1581,8 @@ export default {
     },
 
     initializeSort() {
-      const enabled = this.sortOptions.enabled;
-      const multipleColumns = this.sortOptions.multipleColumns;
-      const initialSortBy = this.sortOptions.initialSortBy || {};
-      const initSortBy = JSON.parse(JSON.stringify(initialSortBy));
+      const { enabled, initialSortBy, multipleColumns } = this.sortOptions;
+      const initSortBy = JSON.parse(JSON.stringify(initialSortBy || {}));
 
       if (typeof enabled === 'boolean') {
         this.sortable = enabled;


### PR DESCRIPTION
Users can pass in `{ enabled: true }` as the sortOptions, which means `initialSortBy` would be `undefined` and `JSON.parse` throws an error when you hand it `undefined`. So we need to default the value if it is not present.