### PR TITLE
Fix search placeholder always forced to null

### DIFF
--- a/src/components/VgtGlobalSearch.vue
+++ b/src/components/VgtGlobalSearch.vue
@@ -12,7 +12,7 @@
       :id="id"
       type="text"
       class="vgt-input vgt-pull-left"
-      :placeholder="null"
+      :placeholder="globalSearchPlaceholder"
       :value="value"
       @input="updateValue($event.target.value)"
       @keyup.enter="entered($event.target.value)" />


### PR DESCRIPTION
Looks like in PR #752 the search field's placeholder text was forced to null. Presumably that was a mistake. This fixes that.