### PR TITLE
avoid "ResizeObserver is not defined"

### DIFF
--- a/src/components/VgtTableHeader.vue
+++ b/src/components/VgtTableHeader.vue
@@ -252,7 +252,7 @@ export default {
   mounted() {
     this.$nextTick(() => {
       // We're going to watch the parent element for resize events, and calculate column widths if it changes
-      if (ResizeObserver) {
+      if ('ResizeObserver' in window) {
         this.ro = new ResizeObserver(() => {
             this.setColumnStyles();
         });


### PR DESCRIPTION
Hey,
I added a fix for situation like mine appeared during tests.

<img width="968" alt="ResizeObserver" src="https://user-images.githubusercontent.com/4216415/113001580-3adfa780-9171-11eb-9313-c2393ec05233.png">
