### PR TITLE
totalPage parameter showing undefined bug fixed

### DIFF
--- a/src/components/pagination/VgtPaginationPageInfo.vue
+++ b/src/components/pagination/VgtPaginationPageInfo.vue
@@ -93,7 +93,7 @@ export default {
         lastRecordOnPage: last,
         totalRecords: this.totalRecords,
         currentPage: this.currentPage,
-        totalPages: this.lastPage,
+        totalPage: this.lastPage,
       };
     },
   },


### PR DESCRIPTION
#853 
`totalPage` key in the pagination information function - `infoParams()` was returning the value as undefined. `totalPage` key was incorrectly spelled as `totalPages`. Renaming it fixed this issue.

![118139294-d62c9380-b424-11eb-95d2-759dc6c6e83b](https://user-images.githubusercontent.com/17634204/118243616-40444780-b4bc-11eb-872b-2ca70330fb78.png)
![image](https://user-images.githubusercontent.com/17634204/118243173-c4e29600-b4bb-11eb-827b-4bf430a679c6.png)

