### PR TITLE
Added support for first and last button in pagination

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -25,6 +25,9 @@
           :rtl="rtl"
           :total="totalRows || totalRowCount"
           :mode="paginationMode"
+          :jumpFirstOrLast="paginationOptions.jumpFirstOrLast"
+          :firstText="firstText"
+          :lastText="lastText"
           :nextText="nextText"
           :prevText="prevText"
           :rowsPerPageText="rowsPerPageText"
@@ -325,6 +328,9 @@
           :rtl="rtl"
           :total="totalRows || totalRowCount"
           :mode="paginationMode"
+          :jumpFirstOrLast="paginationOptions.jumpFirstOrLast"
+          :firstText="firstText"
+          :lastText="lastText"
           :nextText="nextText"
           :prevText="prevText"
           :rowsPerPageText="rowsPerPageText"
@@ -428,6 +434,7 @@ export default {
           dropdownAllowAll: true,
           mode: 'records', // or pages
           infoFn: null,
+          jumpFirstOrLast : false
         };
       },
     },
@@ -450,6 +457,8 @@ export default {
     tableLoading: false,
 
     // text options
+    firstText: "First",
+    lastText: "Last",
     nextText: 'Next',
     prevText: 'Previous',
     rowsPerPageText: 'Rows per page',
@@ -1473,6 +1482,8 @@ export default {
         perPageDropdown,
         perPageDropdownEnabled,
         dropdownAllowAll,
+        firstLabel,
+        lastLabel,
         nextLabel,
         prevLabel,
         rowsPerPageLabel,
@@ -1517,6 +1528,14 @@ export default {
 
       if (typeof mode === 'string') {
         this.paginationMode = mode;
+      }
+
+      if (typeof firstLabel === 'string') {
+        this.firstText = firstLabel;
+      }
+
+      if (typeof lastLabel === 'string') {
+        this.lastText = lastLabel;
       }
 
       if (typeof nextLabel === 'string') {

--- a/src/components/pagination/VgtPagination.vue
+++ b/src/components/pagination/VgtPagination.vue
@@ -33,6 +33,22 @@
         :info-fn="infoFn"
         :mode="mode" />
       <button
+        v-if="jumpFirstOrLast"
+        type="button"
+        aria-controls="vgt-table"
+        class="footer__navigation__page-btn"
+        :class="{ disabled: !firstIsPossible }"
+        @click.prevent.stop="firstPage"
+      >
+        <span
+          aria-hidden="true"
+          class="chevron"
+          v-bind:class="{ left: !rtl, right: rtl }"
+        ></span>
+        <span>{{ firstText }}</span>
+      </button>
+
+      <button
         type="button"
         aria-controls="vgt-table"
         class="footer__navigation__page-btn"
@@ -50,6 +66,22 @@
         @click.prevent.stop="nextPage">
         <span>{{nextText}}</span>
         <span aria-hidden="true" class="chevron" v-bind:class="{ 'right': !rtl, 'left': rtl }"></span>
+      </button>
+
+      <button
+        v-if="jumpFirstOrLast"
+        type="button"
+        aria-controls="vgt-table"
+        class="footer__navigation__page-btn"
+        :class="{ disabled: !lastIsPossible }"
+        @click.prevent.stop="lastPage"
+      >
+        <span>{{ lastText }}</span>
+        <span
+          aria-hidden="true"
+          class="chevron"
+          v-bind:class="{ right: !rtl, left: rtl }"
+        ></span>
       </button>
     </div>
   </div>
@@ -73,8 +105,11 @@ export default {
     customRowsPerPageDropdown: { default() { return []; } },
     paginateDropdownAllowAll: { default: true },
     mode: { default: PAGINATION_MODES.Records },
+    jumpFirstOrLast: { default: false },
 
     // text options
+    firstText: { default: "First" },
+    lastText: { default: "Last" },
     nextText: { default: 'Next' },
     prevText: { default: 'Prev' },
     rowsPerPageText: { default: 'Rows per page:' },
@@ -124,6 +159,16 @@ export default {
       return remainder === 0 ? quotient : quotient + 1;
     },
 
+    // Can go to first page
+    firstIsPossible() {
+      return this.currentPage > 1;
+    },
+
+    // Can go to last page
+    lastIsPossible() {
+      return this.currentPage < Math.ceil(this.total / this.currentPerPage);
+    },
+
     // Can go to next page
     nextIsPossible() {
       return this.currentPage < this.pagesCount;
@@ -145,6 +190,24 @@ export default {
         this.prevPage = this.currentPage;
         this.currentPage = pageNumber;
         this.pageChanged(emit);
+      }
+    },
+
+    // Go to first page
+    firstPage() {
+      if (this.firstIsPossible) {
+        this.currentPage = 1;
+        this.prevPage = 0;
+        this.pageChanged();
+      }
+    },
+
+    // Go to last page
+    lastPage() {
+      if (this.lastIsPossible) {
+        this.currentPage = this.pagesCount;
+        this.prev = this.currentPage - 1;
+        this.pageChanged();
       }
     },
 


### PR DESCRIPTION
#782
Enhanced pagination options. Added support for first and last button which helps in jumping directly to first and last page. Also added support for custom text label of these buttons. Default texts are First and Last.

Support for 3 new pagination options : 
`jumpFirstOrLast : true`
`firstLabel : "1st Page"`
`lastLabel : "Last Page"`

`jumpFirstOrLast` enables support for this enhancement. This prop can take 2 values - true or false. Default value is false.

![image](https://user-images.githubusercontent.com/17634204/118250348-ff503100-b4c3-11eb-85f0-ec06db3fb22c.png)
