### PR TITLE
Fix typo in docs(Collapsable Rows)

### DIFF
--- a/docs/guide/advanced/grouped-table.html
+++ b/docs/guide/advanced/grouped-table.html
@@ -343,7 +343,7 @@ The expanded and collapsed state will then be maintained.</p> <div class="langua
   :rows=&quot;rows&quot;
   :group-options=&quot;{
     enabled: true,
-    rowKey=&quot;id&quot;
+    rowKey:&#39;id&#39;
     collapsable: true // or column index
   }&quot;
 &gt;


### PR DESCRIPTION
I've been using  vue-good-table so well for my project lately. 
But I just found a typo in the documentation.

![image](https://user-images.githubusercontent.com/76241233/132292338-4fd92b67-67b6-42e7-a516-315f848a7082.png)

I kept trying that but it didn't work. 


I think the code should be written like this ⬇
It does work well

![image](https://user-images.githubusercontent.com/76241233/132292506-71fba877-116b-4829-83cf-6918d863118f.png)


