### PR TITLE
typo in documentation. Pagination for both

### DIFF
--- a/vp-docs/guide/configuration/pagination-options.md
+++ b/vp-docs/guide/configuration/pagination-options.md
@@ -93,7 +93,7 @@ For tables that may have many pages, 'pages' mode offers the ability to jump to 
 
 type: `String (default: 'bottom')`
 
-Add pagination on 'top' or 'bottom' (top and bottom) of the table (default position is bottom)
+Add pagination on 'top', 'bottom', or both (top and bottom) of the table (default position is bottom)
 ```html
 <vue-good-table
   :columns="columns"


### PR DESCRIPTION
https://xaksis.github.io/vue-good-table/guide/configuration/pagination-options.html#position

Inside the source code, there's a 'both' option. 
https://github.com/xaksis/vue-good-table/blob/master/src/components/Table.vue#L1509