### PR TITLE
Fix expanded not maintain on another page than first

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -933,6 +933,7 @@ export default {
           if (!hRow) {
             hRow = this.processedRows.find(r => r.vgt_header_id === flatRow.vgt_id);
             if (hRow) {
+              this.handleExpanded(hRow);
               hRow = JSON.parse(JSON.stringify(hRow));
               hRow.children = [];
               reconstructedRows.push(hRow);


### PR DESCRIPTION
When groups are scrollable, and expanded, if we are on another page than the first one, expanded is not maintain on update of data.