### PR TITLE
fix(table-group) 💥 breaks on null children

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -606,10 +606,7 @@ export default {
     showEmptySlot() {
       if (!this.paginated.length) return true;
 
-      if (
-        this.paginated[0].label === 'no groups' &&
-        !this.paginated[0].children.length
-      ) {
+      if (this.paginated[0].label === 'no groups' && !(this.paginated[0].children || []).length){
         return true;
       }
 


### PR DESCRIPTION
✅ This ensures .length is only called on arrays.

### case : 
```
main.js:344 TypeError: Cannot read properties of null (reading 'length')
    at VueComponent.showEmptySlot (vue-good-table.esm.js:13780:82)
```
✅ Root Cause
`this.paginated[0].children` is null or undefined, so accessing .length throws an error.

🧩 Fix 1: Check Your rows Data / santizied the children also works
```
rows = rows.map(r => ({
  ...r,
  children: r.children ?? [], // replace null with empty array
}));

or

function sanitizeRows(rows) {
  return (rows || []).map(row => {
    const sanitized = { ...row };
    if (row.children === null || row.children === undefined) {
      sanitized.children = [];
    } else if (Array.isArray(row.children)) {
      sanitized.children = sanitizeRows(row.children); // recurse
    }
    return sanitized;
  });
}

or

never use rows as null . use [ ] instead
```

🧩 Fix 2: modified dist 😇

